### PR TITLE
[DPE-1939][BUGFIX] Fixing hardcoded default + refactor (`spark8t/lib`)

### DIFF
--- a/spark8t/cli/pyspark.py
+++ b/spark8t/cli/pyspark.py
@@ -4,16 +4,15 @@ import logging
 import re
 from typing import Optional
 
-from spark8t.cli.params import (
+from spark8t.domain import ServiceAccount
+from spark8t.lib.params import (
     add_config_arguments,
     add_logging_arguments,
-    defaults,
-    get_kube_interface,
     k8s_parser,
     parse_arguments_with,
     spark_user_parser,
 )
-from spark8t.domain import ServiceAccount
+from spark8t.lib.process_settings import defaults, get_kube_interface
 from spark8t.services import K8sServiceAccountRegistry, SparkInterface
 
 if __name__ == "__main__":

--- a/spark8t/cli/service_account_registry.py
+++ b/spark8t/cli/service_account_registry.py
@@ -4,16 +4,16 @@ import logging
 from argparse import ArgumentParser
 from enum import Enum
 
-from spark8t.cli.params import (
+from spark8t.domain import PropertyFile, ServiceAccount
+from spark8t.exceptions import NoAccountFound
+from spark8t.lib.params import (
     add_config_arguments,
     add_logging_arguments,
-    get_kube_interface,
     k8s_parser,
     parse_arguments_with,
     spark_user_parser,
 )
-from spark8t.domain import PropertyFile, ServiceAccount
-from spark8t.exceptions import NoAccountFound
+from spark8t.lib.process_settings import get_kube_interface
 from spark8t.services import K8sServiceAccountRegistry, parse_conf_overrides
 
 

--- a/spark8t/cli/spark_shell.py
+++ b/spark8t/cli/spark_shell.py
@@ -4,16 +4,15 @@ import logging
 import re
 from typing import Optional
 
-from spark8t.cli.params import (
+from spark8t.domain import ServiceAccount
+from spark8t.lib.params import (
     add_config_arguments,
     add_logging_arguments,
-    defaults,
-    get_kube_interface,
     k8s_parser,
     parse_arguments_with,
     spark_user_parser,
 )
-from spark8t.domain import ServiceAccount
+from spark8t.lib.process_settings import defaults, get_kube_interface
 from spark8t.services import K8sServiceAccountRegistry, SparkInterface
 
 if __name__ == "__main__":

--- a/spark8t/cli/spark_submit.py
+++ b/spark8t/cli/spark_submit.py
@@ -4,17 +4,16 @@ import logging
 import re
 from typing import Optional
 
-from spark8t.cli.params import (
+from spark8t.domain import ServiceAccount
+from spark8t.lib.params import (
     add_config_arguments,
     add_deploy_arguments,
     add_logging_arguments,
-    defaults,
-    get_kube_interface,
     k8s_parser,
     parse_arguments_with,
     spark_user_parser,
 )
-from spark8t.domain import ServiceAccount
+from spark8t.lib.process_settings import defaults, get_kube_interface
 from spark8t.services import K8sServiceAccountRegistry, SparkInterface
 
 if __name__ == "__main__":

--- a/spark8t/lib/params.py
+++ b/spark8t/lib/params.py
@@ -1,8 +1,5 @@
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser
 from typing import Callable, List, Optional
-
-from spark8t.cli import defaults
-from spark8t.services import AbstractKubeInterface, KubeInterface, LightKube
 
 
 def parse_arguments_with(
@@ -119,13 +116,3 @@ def add_deploy_arguments(parser: ArgumentParser) -> ArgumentParser:
         choices=["client", "cluster"],
     )
     return parser
-
-
-def get_kube_interface(args: Namespace) -> AbstractKubeInterface:
-    return (
-        LightKube(args.kubeconfig or defaults.kube_config, defaults)
-        if args.backend == "lightkube"
-        else KubeInterface(
-            args.kubeconfig or defaults.kube_config, context_name=args.context
-        )
-    )

--- a/spark8t/lib/process_settings.py
+++ b/spark8t/lib/process_settings.py
@@ -10,6 +10,8 @@ def get_kube_interface(args: Namespace) -> AbstractKubeInterface:
         LightKube(args.kubeconfig or defaults.kube_config, defaults)
         if args.backend == "lightkube"
         else KubeInterface(
-            args.kubeconfig or defaults.kube_config, context_name=args.context
+            args.kubeconfig or defaults.kube_config,
+            context_name=args.context,
+            kubectl_cmd=Defaults().kubectl_cmd,
         )
     )

--- a/spark8t/lib/process_settings.py
+++ b/spark8t/lib/process_settings.py
@@ -1,0 +1,15 @@
+from argparse import Namespace
+
+from spark8t.cli import defaults
+from spark8t.domain import Defaults
+from spark8t.services import AbstractKubeInterface, KubeInterface, LightKube
+
+
+def get_kube_interface(args: Namespace) -> AbstractKubeInterface:
+    return (
+        LightKube(args.kubeconfig or defaults.kube_config, defaults)
+        if args.backend == "lightkube"
+        else KubeInterface(
+            args.kubeconfig or defaults.kube_config, context_name=args.context
+        )
+    )

--- a/tests/unittest/test_argument_parsing.py
+++ b/tests/unittest/test_argument_parsing.py
@@ -3,7 +3,8 @@ import logging
 import unittest
 from argparse import ArgumentParser
 
-from spark8t.cli.params import (
+from spark8t.cli.service_account_registry import create_service_account_registry_parser
+from spark8t.lib.params import (
     add_config_arguments,
     add_deploy_arguments,
     add_logging_arguments,
@@ -11,7 +12,6 @@ from spark8t.cli.params import (
     parse_arguments_with,
     spark_user_parser,
 )
-from spark8t.cli.service_account_registry import create_service_account_registry_parser
 from tests import TestCase
 
 


### PR DESCRIPTION
The `Defaults.kubectl_cmd` value (potentially configured by env var `SPARK_KUBECTL`) wasn't taken into account in this command invocation chain.