### PR TITLE
[DPE-2021] integration tests lightkube registry

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -56,8 +56,19 @@ def lightkubeinterface(defs_with_kubeconf):
         interface.client.delete(Namespace, name=ns)
 
 
+def _clearnup_registry(registry):
+    [registry.delete(account.id) for account in registry.all()]
+
+
 @pytest.fixture
-def registry(kubeinterface):
+def kube_registry(kubeinterface):
     registry = K8sServiceAccountRegistry(kubeinterface)
     yield registry
-    [registry.delete(account.id) for account in registry.all()]
+    _clearnup_registry(registry)
+
+
+@pytest.fixture
+def lightkube_registry(lightkubeinterface):
+    registry = K8sServiceAccountRegistry(lightkubeinterface)
+    yield registry
+    _clearnup_registry(registry)


### PR DESCRIPTION
NOTE: Not against `main` but against https://github.com/canonical/spark-k8s-toolkit-py/pull/16