### PR TITLE
minimal modification on the tests

### DIFF
--- a/tests/unittest/test_services.py
+++ b/tests/unittest/test_services.py
@@ -5,7 +5,7 @@ import os
 import unittest
 import uuid
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import yaml
 from lightkube.resources.core_v1 import Secret
@@ -1463,9 +1463,10 @@ class TestServices(TestCase):
             print(call)
 
         mock_kube_interface.create.assert_any_call(
-            KubernetesResourceType.SERVICEACCOUNT,
-            name3,
+            KubernetesResourceType.SECRET_GENERIC,
+            "spark8t-sa-conf-" + name3,
             namespace=namespace3,
+            **{"from-env-file": ANY},
         )
 
         mock_kube_interface.create.assert_any_call(
@@ -1479,10 +1480,10 @@ class TestServices(TestCase):
         )
 
         mock_kube_interface.create.assert_any_call(
-            KubernetesResourceType.ROLEBINDING,
-            f"{name3}-role-binding",
+            KubernetesResourceType.SECRET_GENERIC,
+            "spark8t-sa-conf-" + name3,
             namespace=namespace3,
-            **{"role": f"{name3}-role", "serviceaccount": sa3_obj.id},
+            **{"from-env-file": ANY},
         )
 
         mock_kube_interface.set_label.assert_any_call(

--- a/tests/unittest/test_services.py
+++ b/tests/unittest/test_services.py
@@ -1463,10 +1463,9 @@ class TestServices(TestCase):
             print(call)
 
         mock_kube_interface.create.assert_any_call(
-            KubernetesResourceType.SECRET_GENERIC,
-            "spark8t-sa-conf-" + name3,
-            namespace=namespace3,
-            **{"from-env-file": ANY},
+            KubernetesResourceType.SERVICEACCOUNT,
+            name3,
+            namespace=namespace3, username=name3
         )
 
         mock_kube_interface.create.assert_any_call(
@@ -1480,10 +1479,10 @@ class TestServices(TestCase):
         )
 
         mock_kube_interface.create.assert_any_call(
-            KubernetesResourceType.SECRET_GENERIC,
-            "spark8t-sa-conf-" + name3,
+            KubernetesResourceType.ROLEBINDING,
+            f"{name3}-role-binding",
             namespace=namespace3,
-            **{"from-env-file": ANY},
+            **{"role": f"{name3}-role", "serviceaccount": sa3_obj.id, "username": name3}
         )
 
         mock_kube_interface.set_label.assert_any_call(

--- a/tests/unittest/test_services.py
+++ b/tests/unittest/test_services.py
@@ -1465,7 +1465,8 @@ class TestServices(TestCase):
         mock_kube_interface.create.assert_any_call(
             KubernetesResourceType.SERVICEACCOUNT,
             name3,
-            namespace=namespace3, username=name3
+            namespace=namespace3,
+            username=name3,
         )
 
         mock_kube_interface.create.assert_any_call(
@@ -1482,7 +1483,11 @@ class TestServices(TestCase):
             KubernetesResourceType.ROLEBINDING,
             f"{name3}-role-binding",
             namespace=namespace3,
-            **{"role": f"{name3}-role", "serviceaccount": sa3_obj.id, "username": name3}
+            **{
+                "role": f"{name3}-role",
+                "serviceaccount": sa3_obj.id,
+                "username": name3,
+            },
         )
 
         mock_kube_interface.set_label.assert_any_call(


### PR DESCRIPTION
This is what I meant before. Basically adding username to be consistent with the fact that the `username` argument was added [here](https://github.com/canonical/spark-k8s-toolkit-py/pull/19/files#diff-1addd26d954203294998856da67a6b7faaf1c0accbd8e3059fa30fd646d7e237R1130) and [here](https://github.com/canonical/spark-k8s-toolkit-py/pull/19/files#diff-1addd26d954203294998856da67a6b7faaf1c0accbd8e3059fa30fd646d7e237R1148)