### PR TITLE
[DPE-2085] Error on unrecognizable user input

### DIFF
--- a/spark8t/domain.py
+++ b/spark8t/domain.py
@@ -149,18 +149,28 @@ class PropertyFile(WithLogging):
         }
         return PropertyFile(union(*[simple_properties, merged_options]))
 
-    def remove(self, keys_to_remove: List[str]) -> "PropertyFile":
+    def remove(self, keys_or_pairs: List[str]) -> "PropertyFile":
         """Remove keys from PropertyFile properties.
 
+        Note that keys may also be in the form k=v. In this case, matching with the value is
+        also done before removing the item.
+
         Args:
-            keys_to_remove: List of keys to be removed from properties.
+            keys_or_pairs: List of keys to be removed from properties.
         """
-        self.props = (
+
+        keys_to_remove = set()
+        for key_or_pair in keys_or_pairs:
+            key, *value_list = key_or_pair.split("=")
+            value = "=".join(value_list) if value_list else None
+            if key in self.props and (not value or self.props[key] == value):
+                keys_to_remove.add(key)
+
+        return PropertyFile(
             {key: self.props[key] for key in self.props if key not in keys_to_remove}
             if keys_to_remove
             else self.props
         )
-        return self
 
 
 class Defaults:

--- a/tests/unittest/test_domain.py
+++ b/tests/unittest/test_domain.py
@@ -282,6 +282,34 @@ class TestDomain(TestCase):
         )
         self.assertEqual(registry.get(sa2.id).extra_confs.props, new_props)
 
+    def test_property_removing_conf(self):
+        confs = ["key1=value1", "key2=value2", "key3=value3"]
+
+        prop = PropertyFile(
+            dict(PropertyFile.parse_property_line(line) for line in confs)
+        )
+
+        self.assertFalse("key1" in prop.remove(["key1"]).props)
+
+        self.assertTrue("key3" in prop.remove(["key1", "key2"]).props)
+
+        self.assertDictEqual(prop.props, prop.remove([]).props)
+
+    def test_property_removing_conf_with_pairs(self):
+        confs = ["key1=value1", "key2=value2", "key3=value3"]
+
+        prop = PropertyFile(
+            dict(PropertyFile.parse_property_line(line) for line in confs)
+        )
+
+        self.assertFalse("key1" in prop.remove(["key1=value1"]).props)
+
+        self.assertTrue("key1" in prop.remove(["key1=value2"]).props)
+
+        self.assertFalse("key1" in prop.remove(["key1=value2", "key1=value1"]).props)
+
+        self.assertFalse("key1" in prop.remove(["key1", "key1=value2"]).props)
+
 
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s", level="DEBUG")


### PR DESCRIPTION
Currently providing a key value pair, e.g. `spark.conf.key=value` when deleting configuration does not work (since it assumes that the name is `spark.conf.key=value`. 

The changes proposed allow the code to recognize key and values and removing the property just as long as the stored value correspond with the one provided, e.g. 

```
# Creating a user with given configuration
$  python -m spark8t.cli.service_account_registry create --username spark --namespace spark --conf spark.app.name=my-app-name

# This does NOT remove the property, since the values don't match 
$  python -m spark8t.cli.service_account_registry remove-config --conf spark.app.name=non-existing

# This removes the property, since the values don't match 
$  python -m spark8t.cli.service_account_registry remove-config --conf spark.app.name=my-app-name

# This ALSO removes the property, only providing the key name 
$  python -m spark8t.cli.service_account_registry remove-config --conf spark.app.name
```



