### PR TITLE
[DPE-3552] Fix handling of extraJavaOptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "spark8t"
-version = "0.0.9"
+version = "0.0.10"
 description = "This project provides some utilities function and CLI commands to run Spark on K8s."
 authors = [
     "Canonical Data Platform <data-platform@lists.launchpad.net>"

--- a/spark8t/domain.py
+++ b/spark8t/domain.py
@@ -141,7 +141,7 @@ class PropertyFile(WithLogging):
     @staticmethod
     def _construct_options_string(options: Dict) -> str:
         output = " ".join(f"-D{k}={v}" for k, v in options.items())
-        return f'"{output}"'
+        return f'{output}'
 
     @classmethod
     def empty(cls) -> "PropertyFile":

--- a/spark8t/domain.py
+++ b/spark8t/domain.py
@@ -141,7 +141,7 @@ class PropertyFile(WithLogging):
     @staticmethod
     def _construct_options_string(options: Dict) -> str:
         output = " ".join(f"-D{k}={v}" for k, v in options.items())
-        return f'{output}'
+        return f"{output}"
 
     @classmethod
     def empty(cls) -> "PropertyFile":

--- a/spark8t/literals.py
+++ b/spark8t/literals.py
@@ -1,4 +1,4 @@
 MANAGED_BY_LABELNAME = "app.kubernetes.io/managed-by"
 PRIMARY_LABELNAME = "app.kubernetes.io/spark8t-primary"
 SPARK8S_LABEL = "spark8t"
-HUB_LABEL = "integrator-hub-conf" #TODO revert this label to `integration-hub-conf``
+HUB_LABEL = "integrator-hub-conf"  # TODO revert this label to `integration-hub-conf``

--- a/spark8t/literals.py
+++ b/spark8t/literals.py
@@ -1,4 +1,4 @@
 MANAGED_BY_LABELNAME = "app.kubernetes.io/managed-by"
 PRIMARY_LABELNAME = "app.kubernetes.io/spark8t-primary"
 SPARK8S_LABEL = "spark8t"
-HUB_LABEL = "integration-hub-conf"
+HUB_LABEL = "integrator-hub-conf" #TODO revert this label to `integration-hub-conf``

--- a/spark8t/resources/templates/role_yaml.tmpl
+++ b/spark8t/resources/templates/role_yaml.tmpl
@@ -37,6 +37,6 @@ rules:
   resources:
   - secrets
   resourceNames:
-  - integration-hub-conf-{{username}}
+  - integrator-hub-conf-{{username}}
   verbs:
   - get

--- a/tests/integration/test_registry.py
+++ b/tests/integration/test_registry.py
@@ -161,7 +161,7 @@ def test_merge_configurations():
     expected_merged_props = PropertyFile(
         {
             k1: v13,
-            k2: f'"-Dscala.shell.histfile={v23}"',
+            k2: f'-Dscala.shell.histfile={v23}',
             "key1": "value1",
             "key2": "value2",
             "key3": "value3",

--- a/tests/integration/test_registry.py
+++ b/tests/integration/test_registry.py
@@ -161,7 +161,7 @@ def test_merge_configurations():
     expected_merged_props = PropertyFile(
         {
             k1: v13,
-            k2: f'-Dscala.shell.histfile={v23}',
+            k2: f"-Dscala.shell.histfile={v23}",
             "key1": "value1",
             "key2": "value2",
             "key3": "value3",

--- a/tests/unittest/test_domain.py
+++ b/tests/unittest/test_domain.py
@@ -189,7 +189,7 @@ def test_property_file_parse_options():
 
     scala_hist_file = str(uuid.uuid4())
 
-    props_with_option = f'-Dscala.shell.histfile={scala_hist_file} -Da=A -Db=B -Dc=C'
+    props_with_option = f"-Dscala.shell.histfile={scala_hist_file} -Da=A -Db=B -Dc=C"
 
     conf = PropertyFile(
         props={
@@ -213,7 +213,7 @@ def test_property_file_construct_options_string():
     scala_hist_file = str(uuid.uuid4())
 
     expected_props_with_option = (
-        f'-Dscala.shell.histfile={scala_hist_file} -Da=A -Db=B -Dc=C'
+        f"-Dscala.shell.histfile={scala_hist_file} -Da=A -Db=B -Dc=C"
     )
 
     assert (
@@ -285,11 +285,11 @@ def test_merge_property_file_options(tmp_path, key):
     """
     filename_1 = os.path.join(tmp_path, "test-1.properties")
     with open(filename_1, "w") as fid:
-        fid.write(f'{key}=-Da=A -Db=B')
+        fid.write(f"{key}=-Da=A -Db=B")
 
     filename_2 = os.path.join(tmp_path, "test-2.properties")
     with open(filename_2, "w") as fid:
-        fid.write(f'{key}=-Da=D -Dc=C')
+        fid.write(f"{key}=-Da=D -Dc=C")
 
     conf_1 = PropertyFile.read(filename_1)
     conf_2 = PropertyFile.read(filename_2)
@@ -298,7 +298,7 @@ def test_merge_property_file_options(tmp_path, key):
 
     assert conf_1.options[key]["a"] == "A"
 
-    assert conf_1.props[key] == '-Da=A -Db=B'
+    assert conf_1.props[key] == "-Da=A -Db=B"
 
     merged = conf_1 + conf_2
 
@@ -306,7 +306,7 @@ def test_merge_property_file_options(tmp_path, key):
 
     assert merged.options[key]["a"] == "D"
 
-    assert merged.props[key] == '-Da=D -Db=B -Dc=C'
+    assert merged.props[key] == "-Da=D -Db=B -Dc=C"
 
 
 def test_property_file_log(caplog):

--- a/tests/unittest/test_domain.py
+++ b/tests/unittest/test_domain.py
@@ -240,7 +240,7 @@ def test_property_file_io():
     app_name = str(uuid.uuid4())
     test_config_w = dict()
     contents_java_options = (
-        f'-Dscala.shell.histfile = "{scala_hist_file} -Da=A -Db=B -Dc=C'
+        f"-Dscala.shell.histfile={scala_hist_file} -Da=A -Db=B -Dc=C"
     )
 
     test_config_w["spark.kubernetes.authenticate.driver.serviceAccountName"] = name

--- a/tests/unittest/test_domain.py
+++ b/tests/unittest/test_domain.py
@@ -189,7 +189,7 @@ def test_property_file_parse_options():
 
     scala_hist_file = str(uuid.uuid4())
 
-    props_with_option = f'"-Dscala.shell.histfile={scala_hist_file} -Da=A -Db=B -Dc=C"'
+    props_with_option = f'-Dscala.shell.histfile={scala_hist_file} -Da=A -Db=B -Dc=C'
 
     conf = PropertyFile(
         props={
@@ -213,7 +213,7 @@ def test_property_file_construct_options_string():
     scala_hist_file = str(uuid.uuid4())
 
     expected_props_with_option = (
-        f'"-Dscala.shell.histfile={scala_hist_file} -Da=A -Db=B -Dc=C"'
+        f'-Dscala.shell.histfile={scala_hist_file} -Da=A -Db=B -Dc=C'
     )
 
     assert (
@@ -240,7 +240,7 @@ def test_property_file_io():
     app_name = str(uuid.uuid4())
     test_config_w = dict()
     contents_java_options = (
-        f'-Dscala.shell.histfile = "{scala_hist_file} -Da=A -Db=B -Dc=C"'
+        f'-Dscala.shell.histfile = "{scala_hist_file} -Da=A -Db=B -Dc=C'
     )
 
     test_config_w["spark.kubernetes.authenticate.driver.serviceAccountName"] = name
@@ -285,11 +285,11 @@ def test_merge_property_file_options(tmp_path, key):
     """
     filename_1 = os.path.join(tmp_path, "test-1.properties")
     with open(filename_1, "w") as fid:
-        fid.write(f'{key}="-Da=A -Db=B"')
+        fid.write(f'{key}=-Da=A -Db=B')
 
     filename_2 = os.path.join(tmp_path, "test-2.properties")
     with open(filename_2, "w") as fid:
-        fid.write(f'{key}="-Da=D -Dc=C"')
+        fid.write(f'{key}=-Da=D -Dc=C')
 
     conf_1 = PropertyFile.read(filename_1)
     conf_2 = PropertyFile.read(filename_2)
@@ -298,7 +298,7 @@ def test_merge_property_file_options(tmp_path, key):
 
     assert conf_1.options[key]["a"] == "A"
 
-    assert conf_1.props[key] == '"-Da=A -Db=B"'
+    assert conf_1.props[key] == '-Da=A -Db=B'
 
     merged = conf_1 + conf_2
 
@@ -306,7 +306,7 @@ def test_merge_property_file_options(tmp_path, key):
 
     assert merged.options[key]["a"] == "D"
 
-    assert merged.props[key] == '"-Da=D -Db=B -Dc=C"'
+    assert merged.props[key] == '-Da=D -Db=B -Dc=C'
 
 
 def test_property_file_log(caplog):


### PR DESCRIPTION
This PR addresses the problem of the spark8t library that enclose `extraJavaOptions` in quotes. This breaks the handling of this options by Spark. 