### PR TITLE
[DPE-5016] Hierarchical configuration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Release](https://github.com/canonical/spark-k8s-toolkit-py/actions/workflows/release_github.yaml/badge.svg)](https://github.com/canonical/spark-k8s-toolkit-py/actions/workflows/release_github.yaml)
 [![Tests](https://github.com/canonical/spark-k8s-toolkit-py/actions/workflows/ci-tests.yaml/badge.svg?branch=main)](https://github.com/canonical/spark-k8s-toolkit-py/actions/workflows/ci-tests.yaml?query=branch%3Amain)
 
-A set of Python scripts facilitating Spark interactions over Kunernetes, using an OCI image.
+A set of Python scripts facilitating Spark interactions over Kubernetes, using an OCI image.
 
 ## Description
 
-The main purpose of the `spark8t` toolkit is to provide a seemless, user-friendly interface
-to Spark functionalities over Kubernetes. As much for administator tasks (such as account registration)
+The main purpose of the `spark8t` toolkit is to provide a seamless, user-friendly interface
+to Spark functionalities over Kubernetes. As much for administrator tasks (such as account registration)
 or data scientist functions (such as job submission or Spark interactive shell access). Various
 wrapper scripts allow for persistent (and user-friendly) configuration and execution of related tools.
 
@@ -21,7 +21,7 @@ wrapper scripts allow for persistent (and user-friendly) configuration and execu
 
 Below we describe the essential steps on how to set up a Spark cluster together with the `spark8t` tool.
 
-(However note that most of the "hassle" desribed below can be saved, in case you choose to use the 
+(However note that most of the "hassle" described below can be saved, in case you choose to use the 
 [canonical/spark-client-snap](canonical/spark-client-snap) Snap installation, that would both install
 dependencies, both prepare critical parts of the environment for you.)
 
@@ -50,7 +50,7 @@ Related settings:
 You could install the contents of this repository either by direct checkout, or using `pip` such as
 
 ```
-pip insatll git+https://github.com/canonical/spark-k8s-toolkit-py.git
+pip install git+https://github.com/canonical/spark-k8s-toolkit-py.git
 ```
 
 You'll need to add a mandatory configuration for the tool, which points to the OCI image to be used for the Spark workers.

--- a/spark8t/domain.py
+++ b/spark8t/domain.py
@@ -319,7 +319,7 @@ class ServiceAccount:
     @property
     def configurations(self) -> PropertyFile:
         """Return the service account configuration, associated to a given spark service account."""
-        return self.extra_confs + self.integration_hub_confs + self._k8s_configurations
+        return self.integration_hub_confs + self.extra_confs + self._k8s_configurations
 
 
 class KubernetesResourceType(str, Enum):

--- a/tests/unittest/test_domain.py
+++ b/tests/unittest/test_domain.py
@@ -396,3 +396,21 @@ def test_in_memory_registry():
     }
     assert sa2.id, registry.set_configurations(sa2).id == PropertyFile(props=new_props)
     assert registry.get(sa2.id).extra_confs.props, new_props
+
+
+def test_extra_prop_overrides_hub():
+    # Given
+    apiserver = f"k8s://https://{str(uuid.uuid4())}:{str(uuid.uuid4())}"
+    sa = ServiceAccount(
+        name="name",
+        namespace="namespace",
+        api_server=apiserver,
+        extra_confs=PropertyFile(props={"spark.dummy.property": "extra_value"}),
+        integration_hub_confs=PropertyFile(props={"spark.dummy.property": "hub_value"}),
+    )
+
+    # When
+    configuration = sa.configurations
+
+    # Then
+    assert configuration.props.get("spark.dummy.property", "") == "extra_value"


### PR DESCRIPTION
Changes:
- Service account configuration values take precedence over integration hub's. 
- Fixed a few typos in readme

**The environment**

We added `spark.app.another-name=something_in_the_way` to the integration hub (you can thank Pedro for the inspiration), and `spark.app.another-name=something_in_the_air` to the `test` service account using `spark-client`.

**Before**

```shell
spark-client.service-account-registry get-config --username test --namespace test | grep another-name
# spark.app.another-name=something_in_the_way

spark-client.service-account-registry get-config --username test --namespace test --ignore-integration-hub | grep another-name
# spark.app.another-name=something_in_the_air

spark-client.pyspark --username test --namespace test
```

```python
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /__ / .__/\_,_/_/ /_/\_\   version 3.4.2
      /_/

Using Python version 3.10.12 (main, Sep 11 2024 15:47:36)
Spark context Web UI available at http://192.168.1.103:4040
Spark context available as 'sc' (master = k8s://https://192.168.1.103:16443, app id = spark-6537ceeacf4346dd9640acf23c9cc4e5).
SparkSession available as 'spark'.
>>>
>>> spark.sparkContext._conf.get("spark.app.another-name")
'something_in_the_way'
```

**After**

```shell
python ./spark8t/cli/service_account_registry.py get-config --username test --namespace test | grep another-name
# spark.app.another-name=something_in_the_air

python ./spark8t/cli/service_account_registry.py get-config --username test --namespace test --ignore-integration-hub | grep another-name
# spark.app.another-name=something_in_the_air

python ./spark8t/cli/pyspark.py --username test --namespace test --ignore-integration-hub   
```

```python
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /__ / .__/\_,_/_/ /_/\_\   version 3.4.2
      /_/

Using Python version 3.10.15 (main, Oct 16 2024 04:37:23)
Spark context Web UI available at http://192.168.1.103:4040
Spark context available as 'sc' (master = k8s://https://192.168.1.103:16443, app id = spark-ef4e4299efcd473399912745a66bc878).
SparkSession available as 'spark'.
>>> spark.sparkContext._conf.get("spark.app.another-name")
'something_in_the_air'
```