### PR TITLE
Upgrade tooling

### DIFF
--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: true
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
+          - "3.12"
     steps:
       - id: checkout
         name: Checkout repo

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: true
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
+          - "3.12"
     needs:
       - checks
     steps:

--- a/poetry.lock
+++ b/poetry.lock
@@ -73,7 +73,7 @@ version = "1.17.1"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.8"
-groups = ["unit"]
+groups = ["lint", "unit"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
     {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
@@ -285,7 +285,7 @@ version = "43.0.3"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = ">=3.7"
-groups = ["unit"]
+groups = ["lint", "unit"]
 files = [
     {file = "cryptography-43.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf7a1932ac4176486eab36a19ed4c0492da5d97123f1406cf15e41b05e787d2e"},
     {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63efa177ff54aec6e1c0aefaa1a241232dcd37413835a9b674b6e3f0ae2bfd3e"},
@@ -718,7 +718,7 @@ version = "2.22"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["unit"]
+groups = ["lint", "unit"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
@@ -1020,6 +1020,101 @@ virtualenv = ">=20.26.6"
 test = ["devpi-process (>=1.0.2)", "pytest (>=8.3.3)", "pytest-mock (>=3.14)"]
 
 [[package]]
+name = "types-cffi"
+version = "1.16.0.20241221"
+description = "Typing stubs for cffi"
+optional = false
+python-versions = ">=3.8"
+groups = ["lint"]
+files = [
+    {file = "types_cffi-1.16.0.20241221-py3-none-any.whl", hash = "sha256:e5b76b4211d7a9185f6ab8d06a106d56c7eb80af7cdb8bfcb4186ade10fb112f"},
+    {file = "types_cffi-1.16.0.20241221.tar.gz", hash = "sha256:1c96649618f4b6145f58231acb976e0b448be6b847f7ab733dabe62dfbff6591"},
+]
+
+[package.dependencies]
+types-setuptools = "*"
+
+[[package]]
+name = "types-colorama"
+version = "0.4.15.20240311"
+description = "Typing stubs for colorama"
+optional = false
+python-versions = ">=3.8"
+groups = ["lint"]
+files = [
+    {file = "types-colorama-0.4.15.20240311.tar.gz", hash = "sha256:a28e7f98d17d2b14fb9565d32388e419f4108f557a7d939a66319969b2b99c7a"},
+    {file = "types_colorama-0.4.15.20240311-py3-none-any.whl", hash = "sha256:6391de60ddc0db3f147e31ecb230006a6823e81e380862ffca1e4695c13a0b8e"},
+]
+
+[[package]]
+name = "types-docutils"
+version = "0.21.0.20241128"
+description = "Typing stubs for docutils"
+optional = false
+python-versions = ">=3.8"
+groups = ["lint"]
+files = [
+    {file = "types_docutils-0.21.0.20241128-py3-none-any.whl", hash = "sha256:e0409204009639e9b0bf4521eeabe58b5e574ce9c0db08421c2ac26c32be0039"},
+    {file = "types_docutils-0.21.0.20241128.tar.gz", hash = "sha256:4dd059805b83ac6ec5a223699195c4e9eeb0446a4f7f2aeff1759a4a7cc17473"},
+]
+
+[[package]]
+name = "types-pygments"
+version = "2.19.0.20250107"
+description = "Typing stubs for Pygments"
+optional = false
+python-versions = ">=3.8"
+groups = ["lint"]
+files = [
+    {file = "types_Pygments-2.19.0.20250107-py3-none-any.whl", hash = "sha256:34a555ed327f249daed18c6309e6e62770cdb8b9c321029ba7fd852d10b16f10"},
+    {file = "types_pygments-2.19.0.20250107.tar.gz", hash = "sha256:94de72c7f09b956c518f566e056812c698272a7a03a9cd81f0065576c6bd3219"},
+]
+
+[package.dependencies]
+types-docutils = "*"
+types-setuptools = "*"
+
+[[package]]
+name = "types-pyopenssl"
+version = "24.1.0.20240722"
+description = "Typing stubs for pyOpenSSL"
+optional = false
+python-versions = ">=3.8"
+groups = ["lint"]
+files = [
+    {file = "types-pyOpenSSL-24.1.0.20240722.tar.gz", hash = "sha256:47913b4678a01d879f503a12044468221ed8576263c1540dcb0484ca21b08c39"},
+    {file = "types_pyOpenSSL-24.1.0.20240722-py3-none-any.whl", hash = "sha256:6a7a5d2ec042537934cfb4c9d4deb0e16c4c6250b09358df1f083682fe6fda54"},
+]
+
+[package.dependencies]
+cryptography = ">=35.0.0"
+types-cffi = "*"
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20241230"
+description = "Typing stubs for PyYAML"
+optional = false
+python-versions = ">=3.8"
+groups = ["lint"]
+files = [
+    {file = "types_PyYAML-6.0.12.20241230-py3-none-any.whl", hash = "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6"},
+    {file = "types_pyyaml-6.0.12.20241230.tar.gz", hash = "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c"},
+]
+
+[[package]]
+name = "types-setuptools"
+version = "75.8.0.20250110"
+description = "Typing stubs for setuptools"
+optional = false
+python-versions = ">=3.8"
+groups = ["lint"]
+files = [
+    {file = "types_setuptools-75.8.0.20250110-py3-none-any.whl", hash = "sha256:a9f12980bbf9bcdc23ecd80755789085bad6bfce4060c2275bc2b4ca9f2bc480"},
+    {file = "types_setuptools-75.8.0.20250110.tar.gz", hash = "sha256:96f7ec8bbd6e0a54ea180d66ad68ad7a1d7954e7281a710ea2de75e355545271"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -1056,4 +1151,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "036ffae4b3cd60d9664b2ad95cdf0fb855bac79c0de8c5bd95b5f976d99ff633"
+content-hash = "66096b1580d85a264d6cdfeb75b9a0abe2105ce7abd6b4562f6a21d89bc11f24"

--- a/poetry.lock
+++ b/poetry.lock
@@ -44,6 +44,18 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "cachetools"
+version = "5.5.0"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+groups = ["integration", "unit"]
+files = [
+    {file = "cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292"},
+    {file = "cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a"},
+]
+
+[[package]]
 name = "certifi"
 version = "2024.12.14"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -137,6 +149,18 @@ files = [
 pycparser = "*"
 
 [[package]]
+name = "chardet"
+version = "5.2.0"
+description = "Universal encoding detector for Python 3"
+optional = false
+python-versions = ">=3.7"
+groups = ["integration", "unit"]
+files = [
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
+]
+
+[[package]]
 name = "codespell"
 version = "2.3.0"
 description = "Codespell"
@@ -161,11 +185,11 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["integration", "lint", "unit"]
-markers = "sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {lint = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -306,6 +330,18 @@ test = ["certifi", "cryptography-vectors (==43.0.3)", "pretend", "pytest (>=6.2.
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
+name = "distlib"
+version = "0.3.9"
+description = "Distribution utilities"
+optional = false
+python-versions = "*"
+groups = ["integration", "unit"]
+files = [
+    {file = "distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87"},
+    {file = "distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"},
+]
+
+[[package]]
 name = "envyaml"
 version = "1.10.211231"
 description = "Simple YAML configuration file parser with easy access for structured data"
@@ -342,7 +378,7 @@ version = "3.16.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
-groups = ["lint"]
+groups = ["integration", "lint", "unit"]
 files = [
     {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
     {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
@@ -644,6 +680,23 @@ files = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.3.6"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = false
+python-versions = ">=3.8"
+groups = ["integration", "unit"]
+files = [
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.11.2)"]
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
@@ -690,6 +743,26 @@ cryptography = ">=41.0.5,<45"
 [package.extras]
 docs = ["sphinx (!=5.2.0,!=5.2.0.post0,!=7.2.5)", "sphinx_rtd_theme"]
 test = ["pretend", "pytest (>=3.0.1)", "pytest-rerunfailures"]
+
+[[package]]
+name = "pyproject-api"
+version = "1.8.0"
+description = "API to interact with the python pyproject.toml based projects"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration", "unit"]
+files = [
+    {file = "pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228"},
+    {file = "pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496"},
+]
+
+[package.dependencies]
+packaging = ">=24.1"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "sphinx-autodoc-typehints (>=2.4.1)"]
+testing = ["covdefaults (>=2.3)", "pytest (>=8.3.3)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "setuptools (>=75.1)"]
 
 [[package]]
 name = "pytest"
@@ -919,19 +992,68 @@ files = [
 ]
 
 [[package]]
+name = "tox"
+version = "4.23.2"
+description = "tox is a generic virtualenv management and test command line tool"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration", "unit"]
+files = [
+    {file = "tox-4.23.2-py3-none-any.whl", hash = "sha256:452bc32bb031f2282881a2118923176445bac783ab97c874b8770ab4c3b76c38"},
+    {file = "tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c"},
+]
+
+[package.dependencies]
+cachetools = ">=5.5"
+chardet = ">=5.2"
+colorama = ">=0.4.6"
+filelock = ">=3.16.1"
+packaging = ">=24.1"
+platformdirs = ">=4.3.6"
+pluggy = ">=1.5"
+pyproject-api = ">=1.8"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=4.12.2", markers = "python_version < \"3.11\""}
+virtualenv = ">=20.26.6"
+
+[package.extras]
+test = ["devpi-process (>=1.0.2)", "pytest (>=8.3.3)", "pytest-mock (>=3.14)"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "lint"]
+groups = ["main", "integration", "lint", "unit"]
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
-markers = {main = "python_version < \"3.11\""}
+markers = {main = "python_version < \"3.11\"", integration = "python_version < \"3.11\"", unit = "python_version < \"3.11\""}
+
+[[package]]
+name = "virtualenv"
+version = "20.28.1"
+description = "Virtual Python Environment builder"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration", "unit"]
+files = [
+    {file = "virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb"},
+    {file = "virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329"},
+]
+
+[package.dependencies]
+distlib = ">=0.3.7,<1"
+filelock = ">=3.12.2,<4"
+platformdirs = ">=3.9.1,<5"
+
+[package.extras]
+docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "90c696b6b8802537f6c9d55c3717e5e180112459e004bc590c4bc21407a4231d"
+content-hash = "036ffae4b3cd60d9664b2ad95cdf0fb855bac79c0de8c5bd95b5f976d99ff633"

--- a/poetry.lock
+++ b/poetry.lock
@@ -769,12 +769,8 @@ filelock = ">=3.0"
 mypy = [
     {version = ">=0.900", markers = "python_version >= \"3.11\""},
     {version = ">=0.780", markers = "python_version >= \"3.9\" and python_version < \"3.11\""},
-    {version = ">=0.700", markers = "python_version >= \"3.8\" and python_version < \"3.9\""},
 ]
-pytest = [
-    {version = ">=6.2", markers = "python_version >= \"3.10\""},
-    {version = ">=4.6", markers = "python_version >= \"3.6\" and python_version < \"3.10\""},
-]
+pytest = {version = ">=6.2", markers = "python_version >= \"3.10\""}
 
 [[package]]
 name = "pyyaml"
@@ -937,5 +933,5 @@ markers = {main = "python_version < \"3.11\""}
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">3.8,<4.0"
-content-hash = "33726f9b366f24a88607555785eee629dd214f2e8a62c37aa641759a1647810e"
+python-versions = ">=3.10,<4.0"
+content-hash = "90c696b6b8802537f6c9d55c3717e5e180112459e004bc590c4bc21407a4231d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -6,7 +6,7 @@ version = "4.5.2"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main"]
 files = [
     {file = "anyio-4.5.2-py3-none-any.whl", hash = "sha256:c011ee36bc1e8ba40e5a81cb9df91925c218fe9b778554e0b56a21e1b5d4716f"},
     {file = "anyio-4.5.2.tar.gz", hash = "sha256:23009af4ed04ce05991845451e11ef02fc7c5ed29179ac9a420e5ad0ac7ddc5b"},
@@ -44,71 +44,12 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
-name = "black"
-version = "24.8.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.8"
-groups = ["fmt"]
-files = [
-    {file = "black-24.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09cdeb74d494ec023ded657f7092ba518e8cf78fa8386155e4a03fdcc44679e6"},
-    {file = "black-24.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:81c6742da39f33b08e791da38410f32e27d632260e599df7245cccee2064afeb"},
-    {file = "black-24.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:707a1ca89221bc8a1a64fb5e15ef39cd755633daa672a9db7498d1c19de66a42"},
-    {file = "black-24.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d6417535d99c37cee4091a2f24eb2b6d5ec42b144d50f1f2e436d9fe1916fe1a"},
-    {file = "black-24.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fb6e2c0b86bbd43dee042e48059c9ad7830abd5c94b0bc518c0eeec57c3eddc1"},
-    {file = "black-24.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:837fd281f1908d0076844bc2b801ad2d369c78c45cf800cad7b61686051041af"},
-    {file = "black-24.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62e8730977f0b77998029da7971fa896ceefa2c4c4933fcd593fa599ecbf97a4"},
-    {file = "black-24.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:72901b4913cbac8972ad911dc4098d5753704d1f3c56e44ae8dce99eecb0e3af"},
-    {file = "black-24.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:7c046c1d1eeb7aea9335da62472481d3bbf3fd986e093cffd35f4385c94ae368"},
-    {file = "black-24.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:649f6d84ccbae73ab767e206772cc2d7a393a001070a4c814a546afd0d423aed"},
-    {file = "black-24.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b59b250fdba5f9a9cd9d0ece6e6d993d91ce877d121d161e4698af3eb9c1018"},
-    {file = "black-24.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:6e55d30d44bed36593c3163b9bc63bf58b3b30e4611e4d88a0c3c239930ed5b2"},
-    {file = "black-24.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:505289f17ceda596658ae81b61ebbe2d9b25aa78067035184ed0a9d855d18afd"},
-    {file = "black-24.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b19c9ad992c7883ad84c9b22aaa73562a16b819c1d8db7a1a1a49fb7ec13c7d2"},
-    {file = "black-24.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f13f7f386f86f8121d76599114bb8c17b69d962137fc70efe56137727c7047e"},
-    {file = "black-24.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:f490dbd59680d809ca31efdae20e634f3fae27fba3ce0ba3208333b713bc3920"},
-    {file = "black-24.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eab4dd44ce80dea27dc69db40dab62d4ca96112f87996bca68cd75639aeb2e4c"},
-    {file = "black-24.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3c4285573d4897a7610054af5a890bde7c65cb466040c5f0c8b732812d7f0e5e"},
-    {file = "black-24.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e84e33b37be070ba135176c123ae52a51f82306def9f7d063ee302ecab2cf47"},
-    {file = "black-24.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:73bbf84ed136e45d451a260c6b73ed674652f90a2b3211d6a35e78054563a9bb"},
-    {file = "black-24.8.0-py3-none-any.whl", hash = "sha256:972085c618ee94f402da1af548a4f218c754ea7e5dc70acb168bfaca4c2542ed"},
-    {file = "black-24.8.0.tar.gz", hash = "sha256:2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
-name = "cachetools"
-version = "5.5.0"
-description = "Extensible memoizing collections and decorators"
-optional = false
-python-versions = ">=3.7"
-groups = ["integration", "unit"]
-files = [
-    {file = "cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292"},
-    {file = "cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a"},
-]
-
-[[package]]
 name = "certifi"
 version = "2024.12.14"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main"]
 files = [
     {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
     {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
@@ -196,33 +137,6 @@ files = [
 pycparser = "*"
 
 [[package]]
-name = "chardet"
-version = "5.2.0"
-description = "Universal encoding detector for Python 3"
-optional = false
-python-versions = ">=3.7"
-groups = ["integration", "unit"]
-files = [
-    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
-    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
-]
-
-[[package]]
-name = "click"
-version = "8.1.8"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-groups = ["fmt"]
-files = [
-    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
-    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
 name = "codespell"
 version = "2.3.0"
 description = "Codespell"
@@ -246,12 +160,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["fmt", "integration", "lint", "unit"]
+groups = ["integration", "lint", "unit"]
+markers = "sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {fmt = "platform_system == \"Windows\"", lint = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -392,18 +306,6 @@ test = ["certifi", "cryptography-vectors (==43.0.3)", "pretend", "pytest (>=6.2.
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
-name = "distlib"
-version = "0.3.9"
-description = "Distribution utilities"
-optional = false
-python-versions = "*"
-groups = ["integration", "unit"]
-files = [
-    {file = "distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87"},
-    {file = "distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"},
-]
-
-[[package]]
 name = "envyaml"
 version = "1.10.211231"
 description = "Simple YAML configuration file parser with easy access for structured data"
@@ -424,7 +326,7 @@ version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main", "integration", "lint", "unit"]
 markers = "python_version < \"3.11\""
 files = [
     {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
@@ -440,7 +342,7 @@ version = "3.16.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
-groups = ["integration", "lint", "unit"]
+groups = ["lint"]
 files = [
     {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
     {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
@@ -452,47 +354,12 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "p
 typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
-name = "flake8"
-version = "5.0.4"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.6.1"
-groups = ["lint"]
-files = [
-    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
-    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.9.0,<2.10.0"
-pyflakes = ">=2.5.0,<2.6.0"
-
-[[package]]
-name = "flake8-pyproject"
-version = "1.2.3"
-description = "Flake8 plug-in loading the configuration from pyproject.toml"
-optional = false
-python-versions = ">= 3.6"
-groups = ["lint"]
-files = [
-    {file = "flake8_pyproject-1.2.3-py3-none-any.whl", hash = "sha256:6249fe53545205af5e76837644dc80b4c10037e73a0e5db87ff562d75fb5bd4a"},
-]
-
-[package.dependencies]
-Flake8 = ">=5"
-TOMLi = {version = "*", markers = "python_version < \"3.11\""}
-
-[package.extras]
-dev = ["pyTest", "pyTest-cov"]
-
-[[package]]
 name = "h11"
 version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main"]
 files = [
     {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
     {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
@@ -504,7 +371,7 @@ version = "1.0.7"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main"]
 files = [
     {file = "httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd"},
     {file = "httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c"},
@@ -526,7 +393,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -551,7 +418,7 @@ version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -571,21 +438,6 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
-
-[[package]]
-name = "isort"
-version = "5.13.2"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-groups = ["fmt"]
-files = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "jinja2"
@@ -611,7 +463,7 @@ version = "0.17.1"
 description = "Lightweight kubernetes client library"
 optional = false
 python-versions = "*"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main"]
 files = [
     {file = "lightkube-0.17.1-py3-none-any.whl", hash = "sha256:3d046c2c46191b3745471763710ef4ed2df4259a7405f798b577df2ae390358a"},
     {file = "lightkube-0.17.1.tar.gz", hash = "sha256:e0d6b71476a4fa7cbda7080da1f0943e43c7e747212db9f2ec7d87415bf8d23e"},
@@ -631,7 +483,7 @@ version = "1.32.0.8"
 description = "Models and Resources for lightkube module"
 optional = false
 python-versions = "*"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main"]
 files = [
     {file = "lightkube-models-1.32.0.8.tar.gz", hash = "sha256:97f6c2ab554a23a69554dd56ffbd94173fb416af6490c3a21b1e0b8e13a2bafe"},
     {file = "lightkube_models-1.32.0.8-py3-none-any.whl", hash = "sha256:73786dac63085521f4c88aa69d86bfdc76a67da997c1770e5bdcef8482e4b2a0"},
@@ -708,24 +560,12 @@ files = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-groups = ["lint"]
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
-
-[[package]]
 name = "mypy"
 version = "1.14.1"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["integration", "lint", "unit"]
+groups = ["lint"]
 files = [
     {file = "mypy-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52686e37cf13d559f668aa398dd7ddf1f92c5d613e4f8cb262be2fb4fedb0fcb"},
     {file = "mypy-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1fb545ca340537d4b45d3eecdb3def05e913299ca72c290326be19b3804b39c0"},
@@ -785,7 +625,7 @@ version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
 optional = false
 python-versions = ">=3.5"
-groups = ["fmt", "integration", "lint", "unit"]
+groups = ["lint"]
 files = [
     {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
     {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
@@ -797,55 +637,11 @@ version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["fmt", "integration", "lint", "unit"]
+groups = ["integration", "lint", "unit"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
 ]
-
-[[package]]
-name = "parameterized"
-version = "0.9.0"
-description = "Parameterized testing with any Python test framework"
-optional = false
-python-versions = ">=3.7"
-groups = ["integration"]
-files = [
-    {file = "parameterized-0.9.0-py2.py3-none-any.whl", hash = "sha256:4e0758e3d41bea3bbd05ec14fc2c24736723f243b28d702081aef438c9372b1b"},
-    {file = "parameterized-0.9.0.tar.gz", hash = "sha256:7fc905272cefa4f364c1a3429cbbe9c0f98b793988efb5bf90aac80f08db09b1"},
-]
-
-[package.extras]
-dev = ["jinja2"]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-groups = ["fmt"]
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.3.6"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
-optional = false
-python-versions = ">=3.8"
-groups = ["fmt", "integration", "unit"]
-files = [
-    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
-    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
-]
-
-[package.extras]
-docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
-type = ["mypy (>=1.11.2)"]
 
 [[package]]
 name = "pluggy"
@@ -864,18 +660,6 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
-name = "pycodestyle"
-version = "2.9.1"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.6"
-groups = ["lint"]
-files = [
-    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
-    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"
@@ -886,18 +670,6 @@ markers = "platform_python_implementation != \"PyPy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
-]
-
-[[package]]
-name = "pyflakes"
-version = "2.5.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.6"
-groups = ["lint"]
-files = [
-    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
-    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
 ]
 
 [[package]]
@@ -918,26 +690,6 @@ cryptography = ">=41.0.5,<45"
 [package.extras]
 docs = ["sphinx (!=5.2.0,!=5.2.0.post0,!=7.2.5)", "sphinx_rtd_theme"]
 test = ["pretend", "pytest (>=3.0.1)", "pytest-rerunfailures"]
-
-[[package]]
-name = "pyproject-api"
-version = "1.8.0"
-description = "API to interact with the python pyproject.toml based projects"
-optional = false
-python-versions = ">=3.8"
-groups = ["integration", "unit"]
-files = [
-    {file = "pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228"},
-    {file = "pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496"},
-]
-
-[package.dependencies]
-packaging = ">=24.1"
-tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-docs = ["furo (>=2024.8.6)", "sphinx-autodoc-typehints (>=2.4.1)"]
-testing = ["covdefaults (>=2.3)", "pytest (>=8.3.3)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "setuptools (>=75.1)"]
 
 [[package]]
 name = "pytest"
@@ -987,7 +739,7 @@ version = "3.14.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 optional = false
 python-versions = ">=3.8"
-groups = ["integration", "unit"]
+groups = ["unit"]
 files = [
     {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
     {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
@@ -1030,7 +782,7 @@ version = "6.0.2"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main"]
 files = [
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
@@ -1088,12 +840,40 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.8.6"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["fmt", "lint"]
+files = [
+    {file = "ruff-0.8.6-py3-none-linux_armv6l.whl", hash = "sha256:defed167955d42c68b407e8f2e6f56ba52520e790aba4ca707a9c88619e580e3"},
+    {file = "ruff-0.8.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:54799ca3d67ae5e0b7a7ac234baa657a9c1784b48ec954a094da7c206e0365b1"},
+    {file = "ruff-0.8.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e88b8f6d901477c41559ba540beeb5a671e14cd29ebd5683903572f4b40a9807"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0509e8da430228236a18a677fcdb0c1f102dd26d5520f71f79b094963322ed25"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91a7ddb221779871cf226100e677b5ea38c2d54e9e2c8ed847450ebbdf99b32d"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:248b1fb3f739d01d528cc50b35ee9c4812aa58cc5935998e776bf8ed5b251e75"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bc3c083c50390cf69e7e1b5a5a7303898966be973664ec0c4a4acea82c1d4315"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52d587092ab8df308635762386f45f4638badb0866355b2b86760f6d3c076188"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61323159cf21bc3897674e5adb27cd9e7700bab6b84de40d7be28c3d46dc67cf"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ae4478b1471fc0c44ed52a6fb787e641a2ac58b1c1f91763bafbc2faddc5117"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0c000a471d519b3e6cfc9c6680025d923b4ca140ce3e4612d1a2ef58e11f11fe"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9257aa841e9e8d9b727423086f0fa9a86b6b420fbf4bf9e1465d1250ce8e4d8d"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:45a56f61b24682f6f6709636949ae8cc82ae229d8d773b4c76c09ec83964a95a"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:496dd38a53aa173481a7d8866bcd6451bd934d06976a2505028a50583e001b76"},
+    {file = "ruff-0.8.6-py3-none-win32.whl", hash = "sha256:e169ea1b9eae61c99b257dc83b9ee6c76f89042752cb2d83486a7d6e48e8f764"},
+    {file = "ruff-0.8.6-py3-none-win_amd64.whl", hash = "sha256:f1d70bef3d16fdc897ee290d7d20da3cbe4e26349f62e8a0274e7a3f4ce7a905"},
+    {file = "ruff-0.8.6-py3-none-win_arm64.whl", hash = "sha256:7d7fc2377a04b6e04ffe588caad613d0c460eb2ecba4c0ccbbfe2bc973cbc162"},
+    {file = "ruff-0.8.6.tar.gz", hash = "sha256:dcad24b81b62650b0eb8814f576fc65cfee8674772a6e24c9b747911801eeaa5"},
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -1105,7 +885,7 @@ version = "2.2.1"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["fmt", "integration", "lint", "unit"]
+groups = ["integration", "lint", "unit"]
 markers = "python_version < \"3.11\""
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
@@ -1143,68 +923,19 @@ files = [
 ]
 
 [[package]]
-name = "tox"
-version = "4.23.2"
-description = "tox is a generic virtualenv management and test command line tool"
-optional = false
-python-versions = ">=3.8"
-groups = ["integration", "unit"]
-files = [
-    {file = "tox-4.23.2-py3-none-any.whl", hash = "sha256:452bc32bb031f2282881a2118923176445bac783ab97c874b8770ab4c3b76c38"},
-    {file = "tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c"},
-]
-
-[package.dependencies]
-cachetools = ">=5.5"
-chardet = ">=5.2"
-colorama = ">=0.4.6"
-filelock = ">=3.16.1"
-packaging = ">=24.1"
-platformdirs = ">=4.3.6"
-pluggy = ">=1.5"
-pyproject-api = ">=1.8"
-tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.12.2", markers = "python_version < \"3.11\""}
-virtualenv = ">=20.26.6"
-
-[package.extras]
-test = ["devpi-process (>=1.0.2)", "pytest (>=8.3.3)", "pytest-mock (>=3.14)"]
-
-[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "fmt", "integration", "lint", "unit"]
+groups = ["main", "lint"]
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
-markers = {main = "python_version < \"3.11\"", fmt = "python_version < \"3.11\""}
-
-[[package]]
-name = "virtualenv"
-version = "20.28.1"
-description = "Virtual Python Environment builder"
-optional = false
-python-versions = ">=3.8"
-groups = ["integration", "unit"]
-files = [
-    {file = "virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb"},
-    {file = "virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329"},
-]
-
-[package.dependencies]
-distlib = ">=0.3.7,<1"
-filelock = ">=3.12.2,<4"
-platformdirs = ">=3.9.1,<5"
-
-[package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
-test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
+markers = {main = "python_version < \"3.11\""}
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.8,<4.0"
-content-hash = "da055b7142446bab5c6117efb6e6b607998cf31c3f9623f0d60e8f2f4ee60537"
+content-hash = "33726f9b366f24a88607555785eee629dd214f2e8a62c37aa641759a1647810e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = []
 poetry-plugin-export = ">=1.0"
 
 [tool.poetry.dependencies]
-python = ">3.8,<4.0"
+python = ">=3.10,<4.0"
 lightkube = ">=0.11"
 jinja2 = ">=3.1.2"
 envyaml = ">=1.10.211231"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,51 +1,9 @@
-[tool.pytest.ini_options]
-addopts = "--doctest-modules --cov=./spark8t"
-
-[tool.flake8]
-per-file-ignores = [
-    '__init__.py:F401',
-    'tests/*: D',
-    'tests/test_utils.py: D, F601'
-]
-ignore = [
-    # Ignored by black
-    'E203', 'E266', 'E501', 'W503',
-    # Ignored to conform to PEP257
-    'D203', 'D212', 'D213', 'D214', 'D215', 'D404', 'D405', 'D406', 'D407', 'D408', 'D409', 'D410', 'D411',
-    'D413', 'D415', 'D416', 'D417',
-    # Ignored to work with Sphinx
-    'RST303', 'RST304', 'RST307'
-]
-# line length is intentionally set to 80 here because black uses Bugbear
-# See https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length for more details
-max-line-length = "120"
-max-complexity = "18"
-select = ['B','C','D','E','F','W','T4','B9','RST','DAR']
-docstring_style = "sphinx"
-
-[tool.isort]
-py_version = 3
-profile = 'black'
-known_first_party = ['spark8t','tests']
-skip_gitignore = true
-
-[tool.mypy]
-follow_imports = "silent"
-
-[[tool.mypy.overrides]]
-module = [
-    "parameterized",
-    "envyaml",
-    "pytest"
-]
-ignore_missing_imports = true
-
 [tool.poetry]
 name = "spark8t"
 version = "0.0.11"
 description = "This project provides some utilities function and CLI commands to run Spark on K8s."
 authors = [
-    "Canonical Data Platform <data-platform@lists.launchpad.net>"
+  "Canonical Data Platform <data-platform@lists.launchpad.net>",
 ]
 license = "Apache-2.0"
 readme = "README.md"
@@ -64,46 +22,85 @@ envyaml = ">=1.10.211231"
 optional = true
 
 [tool.poetry.group.fmt.dependencies]
-black = ">=21.12b0"
-isort = ">=5.10"
-lightkube = ">=0.11"
+ruff = "^0.8.6"
 
 [tool.poetry.group.lint]
 optional = true
 
 [tool.poetry.group.lint.dependencies]
+ruff = "^0.8.6"
 codespell = "^2.1.0"
-flake8 = ">=4.0.1"
-Flake8-pyproject = ">=1.1.0"
-mypy = ">=0.910"
+mypy = "^1.0.0"
 pytest-mypy = ">=0.10.3"
-lightkube = ">=0.11"
 
 [tool.poetry.group.unit]
 optional = true
 
 [tool.poetry.group.unit.dependencies]
-tox = ">3.21.4"
-mypy = ">=0.910"
 pytest-cov = ">=3.0"
 pytest = ">=6.2"
 pytest-mock = ">=3.10"
-lightkube = ">=0.11"
 pyOpenSSL = ">=23.1.1"
 
 [tool.poetry.group.integration]
 optional = true
 
 [tool.poetry.group.integration.dependencies]
-tox = ">3.21.4"
-mypy = ">=0.910"
 pytest-cov = ">=3.0"
 pytest = ">=6.2"
-pytest-mock = ">=3.10"
-lightkube = ">=0.11"
-parameterized = ">=0.9.0"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.pytest.ini_options]
+addopts = "--doctest-modules --cov=./spark8t"
+
+[tool.ruff]
+extend-exclude = ["__pycache__", "*.egg_info"]
+target-version = "py38"
+src = ["spark8t", "tests"]
+
+[tool.ruff.lint]
+select = ['B', 'C', 'D', 'E', 'F', 'W', 'B9']
+ignore = ["E501", "D107"]
+extend-ignore = [
+  # Ignored by black
+  'E203',
+  'E266',
+  'E501',
+  # Ignored to conform to PEP257
+  'D203',
+  'D212',
+  'D213',
+  'D214',
+  'D215',
+  'D404',
+  'D405',
+  'D406',
+  'D407',
+  'D408',
+  'D409',
+  'D410',
+  'D411',
+  'D413',
+  'D415',
+  'D416',
+  'D417',
+]
+per-file-ignores = { "__init__.py" = ["F401"], "tests/*" = ["D"], "tests/test_utils.py" = ["F601"] }
+mccabe.max-complexity = 18
+
+[tool.ruff.lint.isort]
+known-first-party = ['spark8t', 'tests']
+
+[tool.mypy]
+follow_imports = "silent"
+
+[[tool.mypy.overrides]]
+module = [
+  "parameterized",
+  "envyaml",
+  "pytest",
+]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ pytest-cov = ">=3.0"
 pytest = ">=6.2"
 pytest-mock = ">=3.10"
 pyOpenSSL = ">=23.1.1"
+tox = "^4.23.2"
 
 [tool.poetry.group.integration]
 optional = true
@@ -48,6 +49,7 @@ optional = true
 [tool.poetry.group.integration.dependencies]
 pytest-cov = ">=3.0"
 pytest = ">=6.2"
+tox = "^4.23.2"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ ruff = "^0.8.6"
 codespell = "^2.1.0"
 mypy = "^1.0.0"
 pytest-mypy = ">=0.10.3"
+types-pyyaml = "^6.0.12.20241230"
+types-pygments = "^2.19.0.20250107"
+types-colorama = "^0.4.15.20240311"
+types-pyopenssl = "^24.1.0.20240722"
 
 [tool.poetry.group.unit]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
-packages = []
+requires-poetry = ">=2.0.0"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.0"
@@ -98,7 +98,7 @@ per-file-ignores = { "__init__.py" = ["F401"], "tests/*" = ["D"], "tests/test_ut
 mccabe.max-complexity = 18
 
 [tool.ruff.lint.isort]
-known-first-party = ['spark8t', 'tests']
+known-first-party = ["spark8t", "tests"]
 
 [tool.mypy]
 follow_imports = "silent"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,37 +1,37 @@
-anyio==4.5.2 ; python_full_version > "3.8.0" and python_version < "4.0" \
+anyio==4.5.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:23009af4ed04ce05991845451e11ef02fc7c5ed29179ac9a420e5ad0ac7ddc5b \
     --hash=sha256:c011ee36bc1e8ba40e5a81cb9df91925c218fe9b778554e0b56a21e1b5d4716f
-certifi==2024.12.14 ; python_full_version > "3.8.0" and python_version < "4.0" \
+certifi==2024.12.14 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56 \
     --hash=sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db
-envyaml==1.10.211231 ; python_full_version > "3.8.0" and python_version < "4.0" \
+envyaml==1.10.211231 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:88f8a076159e3c317d3450a5f404132b6ac91aecee4934ea72eac65f911f1244 \
     --hash=sha256:8d7a7a6be12587cc5da32a587067506b47b849f4643981099ad148015a72de52
-exceptiongroup==1.2.2 ; python_full_version > "3.8.0" and python_version < "3.11" \
+exceptiongroup==1.2.2 ; python_version >= "3.10" and python_version < "3.11" \
     --hash=sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b \
     --hash=sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc
-h11==0.14.0 ; python_full_version > "3.8.0" and python_version < "4.0" \
+h11==0.14.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
     --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
-httpcore==1.0.7 ; python_full_version > "3.8.0" and python_version < "4.0" \
+httpcore==1.0.7 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c \
     --hash=sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd
-httpx==0.28.1 ; python_full_version > "3.8.0" and python_version < "4.0" \
+httpx==0.28.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
-idna==3.10 ; python_full_version > "3.8.0" and python_version < "4.0" \
+idna==3.10 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-jinja2==3.1.5 ; python_full_version > "3.8.0" and python_version < "4.0" \
+jinja2==3.1.5 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb \
     --hash=sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb
-lightkube-models==1.32.0.8 ; python_full_version > "3.8.0" and python_version < "4.0" \
+lightkube-models==1.32.0.8 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:73786dac63085521f4c88aa69d86bfdc76a67da997c1770e5bdcef8482e4b2a0 \
     --hash=sha256:97f6c2ab554a23a69554dd56ffbd94173fb416af6490c3a21b1e0b8e13a2bafe
-lightkube==0.17.1 ; python_full_version > "3.8.0" and python_version < "4.0" \
+lightkube==0.17.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:3d046c2c46191b3745471763710ef4ed2df4259a7405f798b577df2ae390358a \
     --hash=sha256:e0d6b71476a4fa7cbda7080da1f0943e43c7e747212db9f2ec7d87415bf8d23e
-markupsafe==2.1.5 ; python_full_version > "3.8.0" and python_version < "4.0" \
+markupsafe==2.1.5 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf \
     --hash=sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff \
     --hash=sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f \
@@ -92,7 +92,7 @@ markupsafe==2.1.5 ; python_full_version > "3.8.0" and python_version < "4.0" \
     --hash=sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab \
     --hash=sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd \
     --hash=sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68
-pyyaml==6.0.2 ; python_full_version > "3.8.0" and python_version < "4.0" \
+pyyaml==6.0.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff \
     --hash=sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48 \
     --hash=sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086 \
@@ -146,9 +146,9 @@ pyyaml==6.0.2 ; python_full_version > "3.8.0" and python_version < "4.0" \
     --hash=sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba \
     --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
-sniffio==1.3.1 ; python_full_version > "3.8.0" and python_version < "4.0" \
+sniffio==1.3.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
-typing-extensions==4.12.2 ; python_full_version > "3.8.0" and python_version < "3.11" \
+typing-extensions==4.12.2 ; python_version >= "3.10" and python_version < "3.11" \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8

--- a/spark8t/__init__.py
+++ b/spark8t/__init__.py
@@ -1,0 +1,1 @@
+"""This project provides some utilities function and CLI commands to run Spark on K8s."""

--- a/spark8t/cli/__init__.py
+++ b/spark8t/cli/__init__.py
@@ -1,3 +1,5 @@
+"""CLI interface for spark8t."""
+
 import os
 
 from spark8t.domain import Defaults

--- a/spark8t/cli/params.py
+++ b/spark8t/cli/params.py
@@ -1,3 +1,5 @@
+"""Parameters module."""
+
 import logging
 from argparse import ArgumentParser, Namespace
 from typing import Callable, List, Optional
@@ -12,7 +14,7 @@ def parse_arguments_with(
     base_parser: Optional[ArgumentParser] = None,
 ):
     """
-    Specify a chain of parsers to help parse the list of arguments to main
+    Specify a chain of parsers to help parse the list of arguments to main.
 
     :param parsers: List of parsers to be applied.
     :param namespace: Namespace to be used for parsing.
@@ -26,7 +28,7 @@ def parse_arguments_with(
 
 def add_logging_arguments(parser: ArgumentParser) -> ArgumentParser:
     """
-    Add logging argument parsing to the existing parser context
+    Add logging argument parsing to the existing parser context.
 
     :param parser: Input parser to decorate with parsing support for logging args.
     """
@@ -46,7 +48,7 @@ def add_logging_arguments(parser: ArgumentParser) -> ArgumentParser:
 
 def add_ignore_integration_hub(parser: ArgumentParser) -> ArgumentParser:
     """
-    Add option to exclude the configuration provided by the Spark Integration Hub
+    Add option to exclude the configuration provided by the Spark Integration Hub.
 
     :param parser: Input parser to decorate with parsing support for logging args.
     """
@@ -61,7 +63,7 @@ def add_ignore_integration_hub(parser: ArgumentParser) -> ArgumentParser:
 
 def spark_user_parser(parser: ArgumentParser) -> ArgumentParser:
     """
-    Add Spark user related argument parsing to the existing parser context
+    Add Spark user related argument parsing to the existing parser context.
 
     :param parser: Input parser to decorate with parsing support for Spark params.
     """
@@ -82,7 +84,7 @@ def spark_user_parser(parser: ArgumentParser) -> ArgumentParser:
 
 def k8s_parser(parser: ArgumentParser) -> ArgumentParser:
     """
-    Add K8s related argument parsing to the existing parser context
+    Add K8s related argument parsing to the existing parser context.
 
     :param parser: Input parser to decorate with parsing support for Spark params.
     """
@@ -107,7 +109,7 @@ def k8s_parser(parser: ArgumentParser) -> ArgumentParser:
 
 def add_config_arguments(parser: ArgumentParser) -> ArgumentParser:
     """
-    Add arguments to provide extra configurations for the spark properties
+    Add arguments to provide extra configurations for the spark properties.
 
     :param parser: Input parser to decorate with parsing support for deploy arguments.
     """
@@ -128,7 +130,7 @@ def add_config_arguments(parser: ArgumentParser) -> ArgumentParser:
 
 def add_deploy_arguments(parser: ArgumentParser) -> ArgumentParser:
     """
-    Add deployment related argument parsing to the existing parser context
+    Add deployment related argument parsing to the existing parser context.
 
     :param parser: Input parser to decorate with parsing support for deploy arguments.
     """
@@ -143,6 +145,7 @@ def add_deploy_arguments(parser: ArgumentParser) -> ArgumentParser:
 
 
 def get_kube_interface(args: Namespace) -> AbstractKubeInterface:
+    """Get configured kube interface."""
     _class = LightKube if args.backend == "lightkube" else KubeInterface
 
     return _class(
@@ -153,6 +156,7 @@ def get_kube_interface(args: Namespace) -> AbstractKubeInterface:
 def setup_logging(
     log_level: str, config_file: Optional[str], logger_name: Optional[str] = None
 ) -> logging.Logger:
+    """Set up logging from configuration file."""
     with environ(LOG_LEVEL=log_level) as _:
         config_from_file(config_file or DEFAULT_LOGGING_FILE)
     return logging.getLogger(logger_name) if logger_name else logging.root

--- a/spark8t/cli/params.py
+++ b/spark8t/cli/params.py
@@ -2,7 +2,7 @@
 
 import logging
 from argparse import ArgumentParser, Namespace
-from typing import Callable, List, Optional
+from typing import Callable
 
 from spark8t.cli import defaults
 from spark8t.services import AbstractKubeInterface, KubeInterface, LightKube
@@ -10,8 +10,8 @@ from spark8t.utils import DEFAULT_LOGGING_FILE, config_from_file, environ
 
 
 def parse_arguments_with(
-    parsers: List[Callable[[ArgumentParser], ArgumentParser]],
-    base_parser: Optional[ArgumentParser] = None,
+    parsers: list[Callable[[ArgumentParser], ArgumentParser]],
+    base_parser: ArgumentParser | None = None,
 ):
     """
     Specify a chain of parsers to help parse the list of arguments to main.
@@ -154,7 +154,7 @@ def get_kube_interface(args: Namespace) -> AbstractKubeInterface:
 
 
 def setup_logging(
-    log_level: str, config_file: Optional[str], logger_name: Optional[str] = None
+    log_level: str, config_file: str | None, logger_name: str | None = None
 ) -> logging.Logger:
     """Set up logging from configuration file."""
     with environ(LOG_LEVEL=log_level) as _:

--- a/spark8t/cli/pyspark.py
+++ b/spark8t/cli/pyspark.py
@@ -4,7 +4,6 @@
 import re
 from argparse import Namespace
 from logging import Logger
-from typing import Optional
 
 from spark8t.cli.params import (
     add_config_arguments,
@@ -32,7 +31,7 @@ def main(args: Namespace, logger: Logger):
         else kube_interface
     )
 
-    service_account: Optional[ServiceAccount] = (
+    service_account: ServiceAccount | None = (
         registry.get_primary()
         if args.username is None and args.namespace is None
         else registry.get(f"{args.namespace or 'default'}:{args.username or 'spark'}")

--- a/spark8t/cli/pyspark.py
+++ b/spark8t/cli/pyspark.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Pyspark module."""
 
 import re
 from argparse import Namespace
@@ -22,6 +23,7 @@ from spark8t.utils import setup_logging
 
 
 def main(args: Namespace, logger: Logger):
+    """Pyspark main entrypoint."""
     kube_interface = get_kube_interface(args)
 
     registry = K8sServiceAccountRegistry(

--- a/spark8t/cli/service_account_registry.py
+++ b/spark8t/cli/service_account_registry.py
@@ -53,6 +53,13 @@ class Actions(str, Enum):
     PRIMARY = "get-primary"
     LIST = "list"
 
+    def __str__(self) -> str:
+        """Define string representation.
+
+        TODO(py310): replace inheritance with StrEnum once we drop py310
+        """
+        return str.__str__(self)
+
 
 def create_namespace_if_missing(kube_interface: AbstractKubeInterface, namespace: str):
     """Create namespace if does not exist."""

--- a/spark8t/cli/service_account_registry.py
+++ b/spark8t/cli/service_account_registry.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Service account module."""
 
 import subprocess
 from argparse import ArgumentParser, Namespace
@@ -31,6 +32,7 @@ from spark8t.utils import setup_logging
 
 
 def build_service_account_from_args(args, registry) -> ServiceAccount:
+    """Create service account resource interface."""
     return ServiceAccount(
         name=args.username,
         namespace=args.namespace,
@@ -40,6 +42,8 @@ def build_service_account_from_args(args, registry) -> ServiceAccount:
 
 
 class Actions(str, Enum):
+    """Service account CLI action."""
+
     CREATE = "create"
     DELETE = "delete"
     ADD_CONFIG = "add-config"
@@ -58,15 +62,16 @@ def create_namespace_if_missing(kube_interface: AbstractKubeInterface, namespace
         except ApiError as e:
             if e.status.code == 401 or e.status.code == 403:
                 print(f"Namespace {namespace} can not be created.")
-                raise NamespaceNotFound(namespace)
+                raise NamespaceNotFound(namespace) from None
             else:
                 raise e
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as err:
             print(f"Namespace {namespace} can not be created.")
-            raise NamespaceNotFound(namespace)
+            raise NamespaceNotFound(namespace) from err
 
 
 def create_service_account_registry_parser(parser: ArgumentParser):
+    """Create parser for service account CLI."""
     base_parser = parse_arguments_with(
         [add_logging_arguments, k8s_parser],
         ArgumentParser(add_help=False),
@@ -128,6 +133,7 @@ def create_service_account_registry_parser(parser: ArgumentParser):
 
 
 def main(args: Namespace, logger: Logger):
+    """Service account main entrypoint."""
     kube_interface = get_kube_interface(args)
     context = args.context or kube_interface.context_name
 

--- a/spark8t/cli/spark_shell.py
+++ b/spark8t/cli/spark_shell.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Spark shell module."""
 
 import re
 from argparse import Namespace
@@ -22,6 +23,7 @@ from spark8t.utils import setup_logging
 
 
 def main(args: Namespace, logger: Logger):
+    """Shell main entrypoint."""
     kube_interface = get_kube_interface(args)
 
     registry = K8sServiceAccountRegistry(

--- a/spark8t/cli/spark_shell.py
+++ b/spark8t/cli/spark_shell.py
@@ -4,7 +4,6 @@
 import re
 from argparse import Namespace
 from logging import Logger
-from typing import Optional
 
 from spark8t.cli.params import (
     add_config_arguments,
@@ -32,7 +31,7 @@ def main(args: Namespace, logger: Logger):
         else kube_interface
     )
 
-    service_account: Optional[ServiceAccount] = (
+    service_account: ServiceAccount | None = (
         registry.get_primary()
         if args.username is None and args.namespace is None
         else registry.get(f"{args.namespace or 'default'}:{args.username or 'spark'}")

--- a/spark8t/cli/spark_sql.py
+++ b/spark8t/cli/spark_sql.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Spark sql module."""
 
 import re
 from argparse import Namespace
@@ -22,6 +23,7 @@ from spark8t.utils import setup_logging
 
 
 def main(args: Namespace, logger: Logger):
+    """Define SQL main entrypoint."""
     kube_interface = get_kube_interface(args)
 
     registry = K8sServiceAccountRegistry(

--- a/spark8t/cli/spark_sql.py
+++ b/spark8t/cli/spark_sql.py
@@ -4,7 +4,6 @@
 import re
 from argparse import Namespace
 from logging import Logger
-from typing import Optional
 
 from spark8t.cli.params import (
     add_config_arguments,
@@ -32,7 +31,7 @@ def main(args: Namespace, logger: Logger):
         else kube_interface
     )
 
-    service_account: Optional[ServiceAccount] = (
+    service_account: ServiceAccount | None = (
         registry.get_primary()
         if args.username is None and args.namespace is None
         else registry.get(f"{args.namespace or 'default'}:{args.username or 'spark'}")

--- a/spark8t/cli/spark_submit.py
+++ b/spark8t/cli/spark_submit.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Spark submit module."""
 
 import re
 from argparse import Namespace
@@ -23,6 +24,7 @@ from spark8t.utils import setup_logging
 
 
 def main(args: Namespace, logger: Logger):
+    """Submit main entrypoint."""
     kube_interface = get_kube_interface(args)
 
     registry = K8sServiceAccountRegistry(

--- a/spark8t/cli/spark_submit.py
+++ b/spark8t/cli/spark_submit.py
@@ -4,7 +4,6 @@
 import re
 from argparse import Namespace
 from logging import Logger
-from typing import Optional
 
 from spark8t.cli.params import (
     add_config_arguments,
@@ -33,7 +32,7 @@ def main(args: Namespace, logger: Logger):
         else kube_interface
     )
 
-    service_account: Optional[ServiceAccount] = (
+    service_account: ServiceAccount | None = (
         registry.get_primary()
         if args.username is None and args.namespace is None
         else registry.get(f"{args.namespace or 'default'}:{args.username or 'spark'}")

--- a/spark8t/domain.py
+++ b/spark8t/domain.py
@@ -1,11 +1,13 @@
 """Domain module."""
 
+from __future__ import annotations
+
 import io
 import os
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable
 
 from spark8t.utils import WithLogging, union
 
@@ -13,7 +15,7 @@ from spark8t.utils import WithLogging, union
 class PropertyFile(WithLogging):
     """Class for providing basic functionalities for IO properties files."""
 
-    def __init__(self, props: Dict[str, Any]):
+    def __init__(self, props: dict[str, Any]):
         """Initialize a PropertyFile class with data provided by a dictionary.
 
         Args:
@@ -55,7 +57,7 @@ class PropertyFile(WithLogging):
         return True
 
     @staticmethod
-    def parse_property_line(line: str) -> Tuple[str, str]:
+    def parse_property_line(line: str) -> tuple[str, str]:
         """Parse a single configuration line."""
         prop_assignment = list(filter(None, re.split("=| ", line.strip())))
         prop_key = prop_assignment[0].strip()
@@ -64,7 +66,7 @@ class PropertyFile(WithLogging):
         return prop_key, value
 
     @classmethod
-    def _read_property_file_unsafe(cls, name: str) -> Dict:
+    def _read_property_file_unsafe(cls, name: str) -> dict:
         """Read properties in given file into a dictionary.
 
         Args:
@@ -81,7 +83,7 @@ class PropertyFile(WithLogging):
         return defaults
 
     @classmethod
-    def read(cls, filename: str) -> "PropertyFile":
+    def read(cls, filename: str) -> PropertyFile:
         """Read properties file and return a PropertyFile object.
 
         Args:
@@ -92,7 +94,7 @@ class PropertyFile(WithLogging):
         except FileNotFoundError as e:
             raise e
 
-    def write(self, fp: io.TextIOWrapper) -> "PropertyFile":
+    def write(self, fp: io.TextIOWrapper) -> PropertyFile:
         """Write out a property file to disk.
 
         Args:
@@ -103,7 +105,7 @@ class PropertyFile(WithLogging):
             fp.write(line + "\n")
         return self
 
-    def log(self, log_func: Optional[Callable[[str], None]] = None) -> "PropertyFile":
+    def log(self, log_func: Callable[[str], None] | None = None) -> PropertyFile:
         """Print a given dictionary to screen.
 
         Args:
@@ -117,8 +119,8 @@ class PropertyFile(WithLogging):
         return self
 
     @classmethod
-    def _parse_options(cls, options_string: Optional[str]) -> Dict:
-        options: Dict[str, str] = {}
+    def _parse_options(cls, options_string: str | None) -> dict:
+        options: dict[str, str] = {}
 
         if not options_string:
             return options
@@ -132,7 +134,7 @@ class PropertyFile(WithLogging):
         return options
 
     @property
-    def options(self) -> Dict[str, Dict]:
+    def options(self) -> dict[str, dict]:
         """Extract properties which are known to be options-like requiring special parsing."""
         return {
             k: self._parse_options(v)
@@ -141,20 +143,20 @@ class PropertyFile(WithLogging):
         }
 
     @staticmethod
-    def _construct_options_string(options: Dict) -> str:
+    def _construct_options_string(options: dict) -> str:
         output = " ".join(f"-D{k}={v}" for k, v in options.items())
         return f"{output}"
 
     @classmethod
-    def empty(cls) -> "PropertyFile":
+    def empty(cls) -> PropertyFile:
         """Return an empty property file object."""
         return PropertyFile({})
 
-    def __add__(self, other: "PropertyFile"):
+    def __add__(self, other: PropertyFile):
         """Addition operator override."""
         return self.union([other])
 
-    def union(self, others: List["PropertyFile"]) -> "PropertyFile":
+    def union(self, others: list[PropertyFile]) -> PropertyFile:
         """Merge multiple PropertyFile objects, with right to left priority.
 
         Args:
@@ -169,7 +171,7 @@ class PropertyFile(WithLogging):
         }
         return PropertyFile(union(*[simple_properties, merged_options]))
 
-    def remove(self, keys_or_pairs: List[str]) -> "PropertyFile":
+    def remove(self, keys_or_pairs: list[str]) -> PropertyFile:
         """Remove keys from PropertyFile properties.
 
         Note that keys may also be in the form k=v. In this case, matching with the value is
@@ -195,7 +197,7 @@ class PropertyFile(WithLogging):
 class Defaults:
     """Class containing all relevant defaults for the application."""
 
-    def __init__(self, environ: Optional[Dict] = None):
+    def __init__(self, environ: dict | None = None):
         """Initialize a Defaults class using the value contained in a dictionary.
 
         Args:
@@ -234,7 +236,7 @@ class Defaults:
         return self.environ.get("SPARK_KUBECTL", "kubectl")
 
     @property
-    def kube_config(self) -> Union[None, str]:
+    def kube_config(self) -> str | None:
         """Return default kubeconfig to use if provided in env variable."""
         filename = self.environ.get("KUBECONFIG", None)
         return filename if filename else None
@@ -245,7 +247,7 @@ class Defaults:
         return f"{self.spark_confs}/spark-defaults.conf"
 
     @property
-    def env_conf_file(self) -> Optional[str]:
+    def env_conf_file(self) -> str | None:
         """Return env var provided by user to point to the config properties file with conf overrides."""
         return self.environ.get("SPARK_CLIENT_ENV_CONF")
 

--- a/spark8t/domain.py
+++ b/spark8t/domain.py
@@ -352,3 +352,10 @@ class KubernetesResourceType(str, Enum):
     SECRET = "secret"
     SECRET_GENERIC = "secret generic"
     NAMESPACE = "namespace"
+
+    def __str__(self) -> str:
+        """Define string representation.
+
+        TODO(py310): replace inheritance with StrEnum once we drop py310
+        """
+        return str.__str__(self)

--- a/spark8t/domain.py
+++ b/spark8t/domain.py
@@ -1,3 +1,5 @@
+"""Domain module."""
+
 import io
 import os
 import re
@@ -54,6 +56,7 @@ class PropertyFile(WithLogging):
 
     @staticmethod
     def parse_property_line(line: str) -> Tuple[str, str]:
+        """Parse a single configuration line."""
         prop_assignment = list(filter(None, re.split("=| ", line.strip())))
         prop_key = prop_assignment[0].strip()
         option_assignment = line.split("=", 1)
@@ -67,7 +70,7 @@ class PropertyFile(WithLogging):
         Args:
             name: file name to be read
         """
-        defaults = dict()
+        defaults = {}
         with open(name) as f:
             for line in f:
                 # skip empty or commented line
@@ -107,7 +110,6 @@ class PropertyFile(WithLogging):
             log_func: callable to specify another custom printer function. Default uses the class logger with an
                       INFO level.
         """
-
         printer = (lambda msg: self.logger.info(msg)) if log_func is None else log_func
 
         for k, v in self.props.items():
@@ -116,7 +118,7 @@ class PropertyFile(WithLogging):
 
     @classmethod
     def _parse_options(cls, options_string: Optional[str]) -> Dict:
-        options: Dict[str, str] = dict()
+        options: Dict[str, str] = {}
 
         if not options_string:
             return options
@@ -146,9 +148,10 @@ class PropertyFile(WithLogging):
     @classmethod
     def empty(cls) -> "PropertyFile":
         """Return an empty property file object."""
-        return PropertyFile(dict())
+        return PropertyFile({})
 
     def __add__(self, other: "PropertyFile"):
+        """Addition operator override."""
         return self.union([other])
 
     def union(self, others: List["PropertyFile"]) -> "PropertyFile":
@@ -175,7 +178,6 @@ class PropertyFile(WithLogging):
         Args:
             keys_or_pairs: List of keys to be removed from properties.
         """
-
         keys_to_remove = set()
         for key_or_pair in keys_or_pairs:
             key, *value_list = key_or_pair.split("=")
@@ -193,25 +195,29 @@ class PropertyFile(WithLogging):
 class Defaults:
     """Class containing all relevant defaults for the application."""
 
-    def __init__(self, environ: Dict = dict(os.environ)):
-        """Initialize a Defaults class using the value contained in a dictionary
+    def __init__(self, environ: Optional[Dict] = None):
+        """Initialize a Defaults class using the value contained in a dictionary.
 
         Args:
             environ: dictionary representing the environment. Default uses the os.environ key-value pairs.
         """
-
+        if environ is None:
+            environ = dict(os.environ)
         self.environ = environ if environ is not None else {}
 
     @property
     def spark_home(self):
+        """Spark home directory path."""
         return self.environ["SPARK_HOME"]
 
     @property
     def spark_confs(self):
+        """Spark configuration directory path."""
         return self.environ.get("SPARK_CONFS", os.path.join(self.spark_home, "conf"))
 
     @property
     def kubernetes_api(self):
+        """K8s api endpoint."""
         return (
             f"https://{self.environ['KUBERNETES_SERVICE_HOST']}:"
             + f"{self.environ['KUBERNETES_SERVICE_PORT']}"
@@ -219,6 +225,7 @@ class Defaults:
 
     @property
     def spark_user_data(self):
+        """User data path."""
         return self.environ["SPARK_USER_DATA"]
 
     @property
@@ -244,50 +251,62 @@ class Defaults:
 
     @property
     def service_account(self):
+        """Spark service account."""
         return "spark"
 
     @property
     def namespace(self):
+        """Spark operating namespace."""
         return "defaults"
 
     @property
     def scala_history_file(self):
+        """Scala history file path."""
         return f"{self.spark_user_data}/.scala_history"
 
     @property
     def spark_submit(self) -> str:
+        """spark-submit binary path."""
         return f"{self.spark_home}/bin/spark-submit"
 
     @property
     def spark_shell(self) -> str:
+        """spark-shell binary path."""
         return f"{self.spark_home}/bin/spark-shell"
 
     @property
     def pyspark(self) -> str:
+        """Pyspark binary path."""
         return f"{self.spark_home}/bin/pyspark"
 
     @property
     def spark_sql(self) -> str:
+        """spark-sql binary path."""
         return f"{self.spark_home}/bin/spark-sql"
 
     @property
     def dir_package(self) -> str:
+        """Package directory path."""
         return os.path.dirname(__file__)
 
     @property
     def template_dir(self) -> str:
+        """Template directory path."""
         return f"{self.dir_package}/resources/templates"
 
     @property
     def template_serviceaccount(self) -> str:
+        """Service account template path."""
         return f"{self.template_dir}/serviceaccount_yaml.tmpl"
 
     @property
     def template_role(self) -> str:
+        """Role template path."""
         return f"{self.template_dir}/role_yaml.tmpl"
 
     @property
     def template_rolebinding(self) -> str:
+        """Rolebinding template path."""
         return f"{self.template_dir}/rolebinding_yaml.tmpl"
 
 
@@ -323,6 +342,8 @@ class ServiceAccount:
 
 
 class KubernetesResourceType(str, Enum):
+    """Kubernetes resource."""
+
     SERVICEACCOUNT = "serviceaccount"
     ROLE = "role"
     ROLEBINDING = "rolebinding"

--- a/spark8t/exceptions.py
+++ b/spark8t/exceptions.py
@@ -1,3 +1,6 @@
+"""Package specific exception module."""
+
+
 class K8sClusterNotReachable(Exception):
     """Kubernetes cluster cannot be reached successfully by the client."""
 
@@ -27,6 +30,7 @@ class PrimaryAccountNotFound(ResourceNotFound):
         super().__init__("primary")
 
     def __str__(self) -> str:
+        """Str representation."""
         return "Primary account not found. Please create or tag an account as primary."
 
 
@@ -38,9 +42,11 @@ class AccountNotFound(ResourceNotFound):
 
     @property
     def account(self):
+        """Account name."""
         return self.resource_name
 
     def __str__(self) -> str:
+        """Str representation."""
         return f"Account {self.account} could not be found."
 
 
@@ -52,9 +58,11 @@ class NamespaceNotFound(ResourceNotFound):
 
     @property
     def namespace(self):
+        """Namespace denomination."""
         return self.resource_name
 
     def __str__(self) -> str:
+        """Str representation."""
         return f"Namespace {self.namespace} could not be found."
 
 

--- a/spark8t/literals.py
+++ b/spark8t/literals.py
@@ -1,3 +1,5 @@
+"""Literals and constant module."""
+
 MANAGED_BY_LABELNAME = "app.kubernetes.io/managed-by"
 PRIMARY_LABELNAME = "app.kubernetes.io/spark8t-primary"
 SPARK8S_LABEL = "spark8t"

--- a/spark8t/services.py
+++ b/spark8t/services.py
@@ -1596,6 +1596,13 @@ class SparkDeployMode(str, Enum):
     CLIENT = "client"
     CLUSTER = "cluster"
 
+    def __str__(self) -> str:
+        """Define string representation.
+
+        TODO(py310): replace inheritance with StrEnum once we drop py310
+        """
+        return str.__str__(self)
+
 
 class SparkInterface(WithLogging):
     """Class for providing interfaces for spark commands."""

--- a/spark8t/services.py
+++ b/spark8t/services.py
@@ -1,6 +1,8 @@
 # mypy: ignore-errors
 """K8s services module."""
 
+from __future__ import annotations
+
 import base64
 import io
 import json
@@ -11,12 +13,11 @@ from abc import ABC, ABCMeta, abstractmethod
 from enum import Enum
 from functools import cached_property
 from types import MappingProxyType
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any
 
 import yaml
 from lightkube import Client, KubeConfig, SingleConfig, codecs
 from lightkube.core.exceptions import ApiError
-from lightkube.core.resource import GlobalResource
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Namespace, Secret
 from lightkube.resources.core_v1 import ServiceAccount as LightKubeServiceAccount
@@ -58,9 +59,9 @@ class AbstractKubeInterface(WithLogging, metaclass=ABCMeta):
 
     def __init__(
         self,
-        kube_config_file: Union[None, str, Dict[str, Any]],
+        kube_config_file: str | dict[str, Any] | None,
         defaults: Defaults,
-        context_name: Optional[str] = None,
+        context_name: str | None = None,
     ):
         """Initialise a KubeInterface class from a kube config file.
 
@@ -122,15 +123,15 @@ class AbstractKubeInterface(WithLogging, metaclass=ABCMeta):
 
     @abstractmethod
     def get_service_account(
-        self, account_id: str, namespace: Optional[str] = None
-    ) -> Dict[str, Any]:
+        self, account_id: str, namespace: str | None = None
+    ) -> dict[str, Any]:
         """Get service account."""
         pass
 
     @abstractmethod
     def get_service_accounts(
-        self, namespace: Optional[str] = None, labels: Optional[List[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, namespace: str | None = None, labels: list[str] | None = None
+    ) -> list[dict[str, Any]]:
         """Return a list of service accounts, represented as dictionary.
 
         Args:
@@ -142,8 +143,8 @@ class AbstractKubeInterface(WithLogging, metaclass=ABCMeta):
 
     @abstractmethod
     def get_secret(
-        self, secret_name: str, namespace: Optional[str] = None
-    ) -> Dict[str, Any]:
+        self, secret_name: str, namespace: str | None = None
+    ) -> dict[str, Any]:
         """Return the data contained in the specified secret.
 
         Args:
@@ -158,7 +159,7 @@ class AbstractKubeInterface(WithLogging, metaclass=ABCMeta):
         resource_type: KubernetesResourceType,
         resource_name: str,
         label: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ):
         """Set label to a specified resource (type and name).
 
@@ -175,7 +176,7 @@ class AbstractKubeInterface(WithLogging, metaclass=ABCMeta):
         resource_type: KubernetesResourceType,
         resource_name: str,
         label: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ):
         """Remove label to a specified resource (type and name).
 
@@ -192,7 +193,7 @@ class AbstractKubeInterface(WithLogging, metaclass=ABCMeta):
         self,
         resource_type: KubernetesResourceType,
         resource_name: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
         **extra_args,
     ):
         """Create a K8s resource.
@@ -214,7 +215,7 @@ class AbstractKubeInterface(WithLogging, metaclass=ABCMeta):
         self,
         resource_type: KubernetesResourceType,
         resource_name: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ):
         """Delete a K8s resource.
 
@@ -226,7 +227,7 @@ class AbstractKubeInterface(WithLogging, metaclass=ABCMeta):
         pass
 
     def delete_secret_content(
-        self, secret_name: str, namespace: Optional[str] = None
+        self, secret_name: str, namespace: str | None = None
     ) -> None:
         """Delete the content of the specified secret.
 
@@ -239,8 +240,8 @@ class AbstractKubeInterface(WithLogging, metaclass=ABCMeta):
     def add_secret_content(
         self,
         secret_name: str,
-        namespace: Optional[str] = None,
-        configurations: Optional[PropertyFile] = None,
+        namespace: str | None = None,
+        configurations: PropertyFile | None = None,
     ) -> None:
         """Delete the content of the specified secret.
 
@@ -255,7 +256,7 @@ class AbstractKubeInterface(WithLogging, metaclass=ABCMeta):
         self,
         resource_type: KubernetesResourceType,
         resource_name: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ) -> bool:
         """Check if a K8s resource exists.
 
@@ -297,7 +298,7 @@ class AbstractKubeInterface(WithLogging, metaclass=ABCMeta):
 class LightKube(AbstractKubeInterface):
     """Lightkube interface."""
 
-    _obj_mapping: dict[KubernetesResourceType, Type[GlobalResource]] = MappingProxyType(
+    _obj_mapping = MappingProxyType(
         {
             KubernetesResourceType.ROLE: Role,
             KubernetesResourceType.SERVICEACCOUNT: LightKubeServiceAccount,
@@ -322,8 +323,8 @@ class LightKube(AbstractKubeInterface):
         return LightKube(self.kube_config_file, self.defaults, context_name)
 
     def get_service_account(
-        self, account_id: str, namespace: Optional[str] = None
-    ) -> Dict[str, Any]:
+        self, account_id: str, namespace: str | None = None
+    ) -> dict[str, Any]:
         """Return the  named service account entry.
 
         Args:
@@ -350,8 +351,8 @@ class LightKube(AbstractKubeInterface):
             return yaml.safe_load(buffer)
 
     def get_service_accounts(
-        self, namespace: Optional[str] = None, labels: Optional[List[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, namespace: str | None = None, labels: list[str] | None = None
+    ) -> list[dict[str, Any]]:
         """Return a list of service accounts, represented as dictionary.
 
         Args:
@@ -402,8 +403,8 @@ class LightKube(AbstractKubeInterface):
         return result
 
     def get_secret(
-        self, secret_name: str, namespace: Optional[str] = None
-    ) -> Dict[str, Any]:
+        self, secret_name: str, namespace: str | None = None
+    ) -> dict[str, Any]:
         """Return the data contained in the specified secret.
 
         Args:
@@ -436,7 +437,7 @@ class LightKube(AbstractKubeInterface):
             ) from err
 
     def delete_secret_content(
-        self, secret_name: str, namespace: Optional[str] = None
+        self, secret_name: str, namespace: str | None = None
     ) -> None:
         """Delete secret content."""
         if len(self.get_secret(secret_name, namespace)["data"]) == 0:
@@ -457,8 +458,8 @@ class LightKube(AbstractKubeInterface):
     def add_secret_content(
         self,
         secret_name: str,
-        namespace: Optional[str] = None,
-        configurations: Optional[PropertyFile] = None,
+        namespace: str | None = None,
+        configurations: PropertyFile | None = None,
     ) -> None:
         """Delete the content of the specified secret.
 
@@ -478,7 +479,7 @@ class LightKube(AbstractKubeInterface):
         resource_type: KubernetesResourceType,
         resource_name: str,
         label: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ):
         """Set label to a specified resource (type and name).
 
@@ -515,7 +516,7 @@ class LightKube(AbstractKubeInterface):
         resource_type: KubernetesResourceType,
         resource_name: str,
         label: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ):
         """Remove label to a specified resource (type and name).
 
@@ -558,7 +559,7 @@ class LightKube(AbstractKubeInterface):
                 f"Label setting for resource name {resource_type} not supported yet."
             )
 
-    def create_property_file_entries(self, property_file_name) -> Dict[str, str]:
+    def create_property_file_entries(self, property_file_name) -> dict[str, str]:
         """Create property file entries."""
         entries = {}
         props = PropertyFile.read(property_file_name).props
@@ -570,7 +571,7 @@ class LightKube(AbstractKubeInterface):
         self,
         resource_type: KubernetesResourceType,
         resource_name: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
         **extra_args,
     ):
         """Create a K8s resource.
@@ -649,7 +650,7 @@ class LightKube(AbstractKubeInterface):
         self,
         resource_type: KubernetesResourceType,
         resource_name: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ):
         """Delete a K8s resource.
 
@@ -682,7 +683,7 @@ class LightKube(AbstractKubeInterface):
         self,
         resource_type: KubernetesResourceType,
         resource_name: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ) -> bool:
         """Check if resource exists."""
         try:
@@ -699,7 +700,7 @@ class LightKube(AbstractKubeInterface):
             return obj is not None
 
         except ApiError as e:
-            if "not found" in e.status.message:
+            if "not found" in str(e.status.message):
                 return False
             raise e
 
@@ -723,10 +724,10 @@ class KubeInterface(AbstractKubeInterface):
     def exec(
         self,
         cmd: str,
-        namespace: Optional[str] = None,
-        context: Optional[str] = None,
-        output: Optional[str] = None,
-    ) -> Union[str, Dict[str, Any]]:
+        namespace: str | None = None,
+        context: str | None = None,
+        output: str | None = None,
+    ) -> str | dict[str, Any]:
         """Execute command provided as a string.
 
         Args:
@@ -765,7 +766,7 @@ class KubeInterface(AbstractKubeInterface):
 
     def get_service_account(
         self, account_id: str, namespace: str = "default"
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Return the  named service account entry.
 
         Args:
@@ -792,7 +793,7 @@ class KubeInterface(AbstractKubeInterface):
         return service_account_raw
 
     def delete_secret_content(
-        self, secret_name: str, namespace: Optional[str] = None
+        self, secret_name: str, namespace: str | None = None
     ) -> None:
         """Delete the content of the secret name entry.
 
@@ -827,8 +828,8 @@ class KubeInterface(AbstractKubeInterface):
     def add_secret_content(
         self,
         secret_name: str,
-        namespace: Optional[str] = None,
-        configurations: Optional[PropertyFile] = None,
+        namespace: str | None = None,
+        configurations: PropertyFile | None = None,
     ) -> None:
         """Add the content of the specified secret.
 
@@ -868,8 +869,8 @@ class KubeInterface(AbstractKubeInterface):
         self.logger.debug(service_account_raw)
 
     def get_service_accounts(
-        self, namespace: Optional[str] = None, labels: Optional[List[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, namespace: str | None = None, labels: list[str] | None = None
+    ) -> list[dict[str, Any]]:
         """Return a list of service accounts, represented as dictionary.
 
         Args:
@@ -896,8 +897,8 @@ class KubeInterface(AbstractKubeInterface):
         return all_service_accounts_raw["items"]
 
     def get_secret(
-        self, secret_name: str, namespace: Optional[str] = None
-    ) -> Dict[str, Any]:
+        self, secret_name: str, namespace: str | None = None
+    ) -> dict[str, Any]:
         """Return the data contained in the specified secret.
 
         Args:
@@ -931,7 +932,7 @@ class KubeInterface(AbstractKubeInterface):
         resource_type: str,
         resource_name: str,
         label: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ):
         """Set label to a specified resource (type and name).
 
@@ -950,7 +951,7 @@ class KubeInterface(AbstractKubeInterface):
         resource_type: str,
         resource_name: str,
         label: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ):
         """Remove label from to a specified resource."""
         self.exec(
@@ -962,7 +963,7 @@ class KubeInterface(AbstractKubeInterface):
         self,
         resource_type: str,
         resource_name: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
         **extra_args,
     ):
         """Create a K8s resource.
@@ -1021,7 +1022,7 @@ class KubeInterface(AbstractKubeInterface):
             )
 
     def delete(
-        self, resource_type: str, resource_name: str, namespace: Optional[str] = None
+        self, resource_type: str, resource_name: str, namespace: str | None = None
     ):
         """Delete a K8s resource.
 
@@ -1040,7 +1041,7 @@ class KubeInterface(AbstractKubeInterface):
         self,
         resource_type: KubernetesResourceType,
         resource_name: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ) -> bool:
         """Check if resource exists."""
         output = self.exec(
@@ -1051,7 +1052,7 @@ class KubeInterface(AbstractKubeInterface):
 
     @classmethod
     def autodetect(
-        cls, context_name: Optional[str] = None, defaults: Optional[Defaults] = None
+        cls, context_name: str | None = None, defaults: Defaults | None = None
     ) -> "KubeInterface":
         """
         Return a KubeInterface object by auto-parsing the output of the kubectl command.
@@ -1076,7 +1077,7 @@ class AbstractServiceAccountRegistry(WithLogging, ABC):
     """Abstract class for implementing service that manages spark ServiceAccount resources."""
 
     @abstractmethod
-    def all(self, namespace: Optional[str] = None) -> List["ServiceAccount"]:
+    def all(self, namespace: str | None = None) -> list[ServiceAccount]:
         """Return all existing service accounts."""
         pass
 
@@ -1109,7 +1110,7 @@ class AbstractServiceAccountRegistry(WithLogging, ABC):
         pass
 
     @abstractmethod
-    def set_primary(self, account_id: str, namespace: Optional[str]) -> Optional[str]:
+    def set_primary(self, account_id: str, namespace: str | None) -> str | None:
         """Set the primary account to the one related to the provided account id.
 
         Args:
@@ -1117,7 +1118,7 @@ class AbstractServiceAccountRegistry(WithLogging, ABC):
         """
         pass
 
-    def get_primary(self, namespace: Optional[str] = None) -> Optional[ServiceAccount]:
+    def get_primary(self, namespace: str | None = None) -> ServiceAccount | None:
         """Return the primary service account. None is there is no primary service account."""
         all_accounts = self.all(namespace)
 
@@ -1142,7 +1143,7 @@ class AbstractServiceAccountRegistry(WithLogging, ABC):
         return primary_accounts[0]
 
     @abstractmethod
-    def get(self, account_id: str) -> Optional[ServiceAccount]:
+    def get(self, account_id: str) -> ServiceAccount | None:
         """Return the service account associated with the provided account id. None if no account was found.
 
         Args:
@@ -1159,7 +1160,7 @@ class K8sServiceAccountRegistry(AbstractServiceAccountRegistry):
     def __init__(self, kube_interface: AbstractKubeInterface):
         self.kube_interface = kube_interface
 
-    def all(self, namespace: Optional[str] = None) -> List["ServiceAccount"]:
+    def all(self, namespace: str | None = None) -> list[ServiceAccount]:
         """Return all existing service accounts."""
         service_accounts = self.kube_interface.get_service_accounts(
             namespace=namespace, labels=[f"{MANAGED_BY_LABELNAME}={SPARK8S_LABEL}"]
@@ -1194,7 +1195,7 @@ class K8sServiceAccountRegistry(AbstractServiceAccountRegistry):
             }
         )
 
-    def _build_service_account_from_raw(self, metadata: Dict[str, Any]):
+    def _build_service_account_from_raw(self, metadata: dict[str, Any]):
         name = metadata["name"]
         namespace = metadata["namespace"]
         primary = PRIMARY_LABELNAME in metadata["labels"]
@@ -1215,9 +1216,7 @@ class K8sServiceAccountRegistry(AbstractServiceAccountRegistry):
             ),
         )
 
-    def set_primary(
-        self, account_id: str, namespace: Optional[str] = None
-    ) -> Optional[str]:
+    def set_primary(self, account_id: str, namespace: str | None = None) -> str | None:
         """Set the primary account to the one related to the provided account id.
 
         Args:
@@ -1457,7 +1456,7 @@ class K8sServiceAccountRegistry(AbstractServiceAccountRegistry):
 
         return account_id
 
-    def get(self, account_id: str) -> Optional[ServiceAccount]:
+    def get(self, account_id: str) -> ServiceAccount | None:
         """Get service account."""
         namespace, username = account_id.split(":")
         try:
@@ -1472,7 +1471,7 @@ class K8sServiceAccountRegistry(AbstractServiceAccountRegistry):
 class InMemoryAccountRegistry(AbstractServiceAccountRegistry):
     """In memory implementation for account registry."""
 
-    def __init__(self, cache: Dict[str, ServiceAccount]):
+    def __init__(self, cache: dict[str, ServiceAccount]):
         self.cache = cache
 
         self._consistency_check()
@@ -1485,7 +1484,7 @@ class InMemoryAccountRegistry(AbstractServiceAccountRegistry):
                 "There exists more than one primary in the service account registry."
             )
 
-    def all(self, namespace: Optional[str] = None) -> List["ServiceAccount"]:
+    def all(self, namespace: str | None = None) -> list[ServiceAccount]:
         """Return all existing service accounts."""
         return [
             service_account
@@ -1523,7 +1522,7 @@ class InMemoryAccountRegistry(AbstractServiceAccountRegistry):
         """
         return self.cache.pop(account_id).id
 
-    def set_primary(self, account_id: str, namespace: Optional[str] = None) -> str:
+    def set_primary(self, account_id: str, namespace: str | None = None) -> str:
         """Set the primary account to the one related to the provided account id.
 
         Args:
@@ -1557,13 +1556,13 @@ class InMemoryAccountRegistry(AbstractServiceAccountRegistry):
         self.cache[account_id].extra_confs = configurations
         return account_id
 
-    def get(self, account_id: str) -> Optional[ServiceAccount]:
+    def get(self, account_id: str) -> ServiceAccount | None:
         """Get service account."""
         return self.cache.get(account_id)
 
 
 def parse_conf_overrides(
-    conf_args: List, environ_vars: Optional[Dict] = None
+    conf_args: list, environ_vars: dict | None = None
 ) -> PropertyFile:
     """Parse --conf overrides passed to spark-submit.
 
@@ -1618,7 +1617,7 @@ class SparkInterface(WithLogging):
         self.defaults = defaults
 
     @staticmethod
-    def _read_properties_file(namefile: Optional[str]) -> PropertyFile:
+    def _read_properties_file(namefile: str | None) -> PropertyFile:
         return (
             PropertyFile.read(namefile)
             if namefile is not None
@@ -1626,7 +1625,7 @@ class SparkInterface(WithLogging):
         )
 
     @staticmethod
-    def _generate_properties_file_from_arguments(confs: List[str]):
+    def _generate_properties_file_from_arguments(confs: list[str]):
         if not confs:
             return PropertyFile({})
 
@@ -1641,9 +1640,9 @@ class SparkInterface(WithLogging):
     def spark_submit(
         self,
         deploy_mode: SparkDeployMode,
-        confs: List[str],
-        cli_property: Optional[str],
-        extra_args: List[str],
+        confs: list[str],
+        cli_property: str | None,
+        extra_args: list[str],
     ):
         """Submit a spark job.
 
@@ -1687,7 +1686,7 @@ class SparkInterface(WithLogging):
                 os.system(submit_cmd)
 
     def spark_shell(
-        self, confs: List[str], cli_property: Optional[str], extra_args: List[str]
+        self, confs: list[str], cli_property: str | None, extra_args: list[str]
     ):
         """Start an interactinve spark shell.
 
@@ -1743,7 +1742,7 @@ class SparkInterface(WithLogging):
                 os.system(submit_cmd)
 
     def pyspark_shell(
-        self, confs: List[str], cli_property: Optional[str], extra_args: List[str]
+        self, confs: list[str], cli_property: str | None, extra_args: list[str]
     ):
         """Start an interactinve pyspark shell.
 
@@ -1794,9 +1793,9 @@ class SparkInterface(WithLogging):
 
     def spark_sql(
         self,
-        confs: List[str],
-        cli_property: Optional[str],
-        extra_args: List[str],
+        confs: list[str],
+        cli_property: str | None,
+        extra_args: list[str],
     ):
         """Start an interactive Spark SQL shell.
 

--- a/spark8t/utils.py
+++ b/spark8t/utils.py
@@ -11,24 +11,13 @@ from copy import deepcopy as copy
 from functools import reduce
 from logging import Logger, config, getLogger
 from tempfile import NamedTemporaryFile
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Mapping,
-    Optional,
-    TypedDict,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Literal, Mapping, TypedDict, TypeVar, TypeAlias
 from urllib.parse import quote, unquote
 
 import yaml
 from envyaml import EnvYAML
 
-PathLike = Union[str, "os.PathLike[str]"]
+PathLike: TypeAlias = str | os.PathLike[str]
 
 LevelTypes = Literal[
     "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET", 50, 40, 30, 20, 10, 0
@@ -132,7 +121,7 @@ class WithLogging:
         return getLogger(nameLogger)
 
     def logResult(
-        self, msg: Union[Callable[..., str], str], level: StrLevelTypes = "INFO"
+        self, msg: Callable[..., str] | str, level: StrLevelTypes = "INFO"
     ) -> Callable[..., Any]:
         """Return a decorator to allow logging of inputs/outputs.
 
@@ -152,7 +141,7 @@ class WithLogging:
 
 
 def setup_logging(
-    log_level: str, config_file: Optional[str] = None, logger_name: Optional[str] = None
+    log_level: str, config_file: str | None = None, logger_name: str | None = None
 ) -> logging.Logger:
     """Set up logging from configuration file."""
     with environ(LOG_LEVEL=log_level) as _:
@@ -193,11 +182,11 @@ def union(*dicts: dict) -> dict:
     return reduce(__dict_merge, dicts)
 
 
-def _check(value: Optional[T]) -> bool:
+def _check(value: Any) -> bool:
     return False if value is None else True
 
 
-def filter_none(_dict: Dict[T, Any]) -> Dict[T, Any]:
+def filter_none(_dict: dict[T, Any]) -> dict[T, Any]:
     """
     Return a dictionary where the key,value pairs are filtered where the value is None.
 
@@ -248,7 +237,7 @@ def create_dir_if_not_exists(directory: PathLike) -> PathLike:
     return directory
 
 
-def parse_yaml_shell_output(cmd: str) -> Union[Dict[str, Any], str]:
+def parse_yaml_shell_output(cmd: str) -> dict[str, Any] | str:
     """
     Execute command and parse output as YAML.
 
@@ -321,7 +310,7 @@ def environ(*remove, **update):
         env.update(update_after)
 
 
-def listify(value: Any) -> List[str]:
+def listify(value: Any) -> list[str]:
     """Flatten potentially nested structure."""
     return [str(v) for v in value] if isinstance(value, list) else [str(value)]
 

--- a/spark8t/utils.py
+++ b/spark8t/utils.py
@@ -39,6 +39,8 @@ T = TypeVar("T")
 
 
 class LevelsDict(TypedDict):
+    """Logger levels."""
+
     CRITICAL: Literal[50]
     ERROR: Literal[40]
     WARNING: Literal[30]
@@ -65,7 +67,7 @@ DEFAULT_LOGGING_FILE = os.path.join(
 
 def config_from_json(path_to_file: str = DEFAULT_LOGGING_FILE) -> None:
     """
-    Configure logger from json
+    Configure logger from json.
 
     :param path_to_file: path to configuration file
 
@@ -80,7 +82,7 @@ def config_from_json(path_to_file: str = DEFAULT_LOGGING_FILE) -> None:
 
 def config_from_yaml(path_to_file: str = DEFAULT_LOGGING_FILE) -> None:
     """
-    Configure logger from yaml
+    Configure logger from yaml.
 
     :param path_to_file: path to configuration file
 
@@ -93,7 +95,7 @@ def config_from_yaml(path_to_file: str = DEFAULT_LOGGING_FILE) -> None:
 
 def config_from_file(path_to_file: str = DEFAULT_LOGGING_FILE) -> None:
     """
-    Configure logger from file
+    Configure logger from file.
 
     :param path_to_file: path to configuration file
 
@@ -101,7 +103,6 @@ def config_from_file(path_to_file: str = DEFAULT_LOGGING_FILE) -> None:
 
     :return: configuration for logger
     """
-
     readers = {
         ".yml": config_from_yaml,
         ".yaml": config_from_yaml,
@@ -123,9 +124,9 @@ class WithLogging:
 
     @property
     def logger(self) -> Logger:
-        """
-        Create logger.
-        :return: default logger
+        """Create logger.
+
+        :return: default logger.
         """
         nameLogger = str(self.__class__).replace("<class '", "").replace("'>", "")
         return getLogger(nameLogger)
@@ -133,11 +134,11 @@ class WithLogging:
     def logResult(
         self, msg: Union[Callable[..., str], str], level: StrLevelTypes = "INFO"
     ) -> Callable[..., Any]:
-        """
-        Return a decorator to allow logging of inputs/outputs.
+        """Return a decorator to allow logging of inputs/outputs.
+
         :param msg: message to log
         :param level: logging level
-        :return: wrapped method
+        :return: wrapped method.
         """
 
         def wrap(x: Any) -> Any:
@@ -153,6 +154,7 @@ class WithLogging:
 def setup_logging(
     log_level: str, config_file: Optional[str] = None, logger_name: Optional[str] = None
 ) -> logging.Logger:
+    """Set up logging from configuration file."""
     with environ(LOG_LEVEL=log_level) as _:
         config_from_file(config_file or DEFAULT_LOGGING_FILE)
     return logging.getLogger(logger_name) if logger_name else logging.root
@@ -161,21 +163,23 @@ def setup_logging(
 def union(*dicts: dict) -> dict:
     """
     Return a dictionary that results from the recursive merge of the input dictionaries.
+
     :param dicts: list of dicts
-    :return: merged dict
+    :return: merged dict.
     """
 
     def __dict_merge(dct: dict, merge_dct: dict):
         """
         Recursive dict merge.
+
         Inspired by :meth:``dict.update()``, instead of updating only top-level keys, dict_merge recurses down into
         dicts nested to an arbitrary depth, updating keys. The ``merge_dct`` is merged into ``dct``.
         :param dct: dict onto which the merge is executed
         :param merge_dct: dct merged into dct
-        :return: None
+        :return: None.
         """
         merged = copy(dct)
-        for k, v in merge_dct.items():
+        for k, _v in merge_dct.items():
             if (
                 k in dct
                 and isinstance(dct[k], dict)
@@ -219,10 +223,10 @@ def umask_named_temporary_file(*args, **kargs):
 
 
 def mkdir(path: PathLike) -> None:
-    """
-    Create a dir, using a formulation consistent between 2.x and 3.x python versions.
+    """Create a dir, using a formulation consistent between 2.x and 3.x python versions.
+
     :param path: path to create
-    :raises OSError: whenever OSError is raised by makedirs and it's not because the directory exists
+    :raises OSError: whenever OSError is raised by makedirs and it's not because the directory exists.
     """
     try:
         os.makedirs(path)
@@ -234,10 +238,10 @@ def mkdir(path: PathLike) -> None:
 
 
 def create_dir_if_not_exists(directory: PathLike) -> PathLike:
-    """
-    Create a directory if it does not exist.
+    """Create a directory if it does not exist.
+
     :param directory: path
-    :return: directory, str
+    :return: directory, str.
     """
     if not os.path.exists(directory):
         os.makedirs(directory)
@@ -318,6 +322,7 @@ def environ(*remove, **update):
 
 
 def listify(value: Any) -> List[str]:
+    """Flatten potentially nested structure."""
     return [str(v) for v in value] if isinstance(value, list) else [str(value)]
 
 
@@ -340,6 +345,7 @@ class PercentEncodingSerializer:
         return "".join([self.percent_char] * 2)
 
     def serialize(self, input_string: str) -> str:
+        """Serialize percent encoded input."""
         return (
             quote(input_string)
             .replace(self.percent_char, self._double_percent_char)
@@ -347,6 +353,7 @@ class PercentEncodingSerializer:
         )
 
     def deserialize(self, input_string: str) -> str:
+        """Deserialize percent encoded input."""
         return unquote(
             input_string.replace(self._double_percent_char, self._SPECIAL)
             .replace(self.percent_char, "%")

--- a/tests/integration/test_cli_service_accounts.py
+++ b/tests/integration/test_cli_service_accounts.py
@@ -744,7 +744,7 @@ def test_service_account_add_config(service_account, backend, request):
     # Check if newly added configs are added successfully
     added_configs = updated_configs - original_configs
 
-    assert added_configs == set([config_to_add])
+    assert added_configs == {config_to_add}
 
 
 @pytest.mark.parametrize("backend", VALID_BACKENDS)

--- a/tests/unittest/test_domain.py
+++ b/tests/unittest/test_domain.py
@@ -48,7 +48,7 @@ def test_defaults_kube_config():
 
     from spark8t.utils import environ
 
-    d = Defaults(dict())
+    d = Defaults({})
 
     assert d.kube_config is None
 
@@ -238,7 +238,7 @@ def test_property_file_io():
 
     scala_hist_file = str(uuid.uuid4())
     app_name = str(uuid.uuid4())
-    test_config_w = dict()
+    test_config_w = {}
     contents_java_options = (
         f"-Dscala.shell.histfile={scala_hist_file} -Da=A -Db=B -Dc=C"
     )

--- a/tox.ini
+++ b/tox.ini
@@ -26,18 +26,18 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 commands =
-    poetry install --only fmt 
-    poetry run isort {[vars]all_path}
-    poetry run black {[vars]all_path}
+    poetry install --only fmt
+    poetry run ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    poetry install --only fmt,lint
+    poetry install --only lint
+    poetry run ruff check --fix {[vars]all_path}
+    poetry run ruff format --check {[vars]all_path}
     poetry run codespell {[vars]all_path} pyproject.toml
-    poetry run flake8 {[vars]all_path}
-    poetry run isort --check-only --diff {[vars]all_path}
-    poetry run black --check --diff {[vars]all_path}
+
+    poetry install --with lint
     poetry run mypy --install-types --non-interactive {[vars]all_path} --exclude {[vars]int_resources_path}
 
 [testenv:unit]

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
     poetry run codespell {[vars]all_path} pyproject.toml
 
     poetry install --with lint
-    poetry run mypy --install-types --non-interactive {[vars]all_path} --exclude {[vars]int_resources_path}
+    poetry run mypy {[vars]all_path} --exclude {[vars]int_resources_path}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
## Changes

- Align our tooling with our other products
- Drop support for Python 3.8 and 3.9. Our default runtime is Jammy, which comes with 3.10
    - upgraded type hints for a more modern code base
- Fix compatibility with Python 3.11+
- The previous flake8 configuration was not properly enforced for some reason. Migrating to ruff made me fix a bunch of violations (which means adding low value docstrings, to be honest)


We have some unused or outdated stuff that we could remove:
- `utils.py`
    - `union()`: we use it for `PropertyFile` objects which are only one level data structure AFAICT. The `|` operator is sufficient
    - `_check()`: used in one place in `filter_none`, trivial to inline this
    - `mkdir()`
    - `create_dir_if_not_exists()`
- `exceptions.py`
    - `K8sClusterNotReachable`
- `services.py`
    - `InMemoryAccountRegistry` is only used in unit tests, maybe it could go there?  We would not have to distribute it in the package