### PR TITLE
[PRA-354] Prettify and improve renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,18 +1,24 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>canonical/data-platform//renovate_presets/charm.json5",
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "github>canonical/data-platform//renovate_presets/base.json5",
+    "helpers:pinGitHubActionDigests",
   ],
-  "reviewers": [
-    "welpaolo",
-    "theoctober19th",
-    "batalex",
-  ],
-  // Between 1AM and 6:59AM, first Friday of the month
-  "schedule": ["* 1-6 1-7 * 5"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["* 1-6 1-7 * 5"]
+  // Between 1AM and 6:59AM, Friday mid-month
+  schedule: ["* 1-6 14-21 * 5"],
+  lockFileMaintenance: {
+    enabled: true,
+    // Between 1AM and 6:59AM, first Friday of the month
+    schedule: ["* 1-6 1-7 * 5"],
   },
-  "ignoreDeps": ["ubuntu"]
+  commitMessagePrefix: "[RENOVATE] ",
+  ignoreDeps: ["ubuntu"],
+  enabledManagers: ["github-actions", "poetry"],
+  packageRules: [
+    {
+      description: "Require manual approval on Dashboard for major updates",
+      matchUpdateTypes: ["major"],
+      dependencyDashboardApproval: true,
+    },
+  ],
 }


### PR DESCRIPTION
This PR prettifies and improves the renovate configuration.

## Changes
- Adopted the same schedule as charms so that we have two weeks to handle the majority of the upgrades to eventually release a new version to be picked by the rocks on the first Friday of the month. Similar to what we do for charms, the lockfile maintenance has a two weeks offset (so back to the first Friday of the month) to avoid conflicts on `poetry.lock`
- Removed reviewer assignment since we have a CODEOWNERS
- We now use the base preset instead of the charm one, since we don't have a charmcraft.yaml file here. This meant we had to enable the `poetry` manager though
- Major updates need to be manually triggered from the dashboard, to reduce the # of PRs
- GH actions are pinned to their digest